### PR TITLE
Delete all TF references to BBP cidr variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,6 @@ module "ml" {
   generic_private_alb_security_group_id = data.terraform_remote_state.common.outputs.generic_private_alb_security_group_id
 
   github_repos                           = ["BlueBrain/neuroagent", "BlueBrain/scholarag", "BlueBrain/scholaretl"]
-  bbp_dmz_cidr                           = var.bbp_dmz_cidr
   readonly_access_policy_statement_part1 = local.readonly_access_policy_statement_part1
   readonly_access_policy_statement_part2 = local.readonly_access_policy_statement_part2
   aws_ssoadmin_instances_arns            = data.aws_ssoadmin_instances.ssoadmin_instances.arns
@@ -281,7 +280,7 @@ module "accounting_svc" {
   vpc_id                        = local.vpc_id
   private_alb_listener_arn      = local.private_alb_https_listener_arn
   internet_access_route_id      = local.route_table_private_subnets_id
-  allowed_source_ip_cidr_blocks = [var.bbp_dmz_cidr, local.vpc_cidr_block, ]
+  allowed_source_ip_cidr_blocks = [local.vpc_cidr_block]
 
   accounting_service_secrets_arn = local.accounting_service_secrets_arn
 

--- a/ml/agent.tf
+++ b/ml/agent.tf
@@ -212,7 +212,7 @@ resource "aws_lb_listener_rule" "generic_private_agent_rule" {
 
   condition {
     source_ip {
-      values = [var.bbp_dmz_cidr]
+      values = [var.vpc_cidr_block]
     }
   }
 }

--- a/ml/variables.tf
+++ b/ml/variables.tf
@@ -208,10 +208,6 @@ variable "tags" {
   default     = { SBO_Billing = "machinelearning" }
 }
 
-variable "bbp_dmz_cidr" {
-  type = string
-}
-
 variable "readonly_access_policy_statement_part1" {
   description = "Policy for read-only permission pt2"
   type        = string

--- a/ssh-bastion-vms-on-public-subnets.tf
+++ b/ssh-bastion-vms-on-public-subnets.tf
@@ -145,32 +145,6 @@ resource "aws_vpc_security_group_ingress_rule" "ssh_bastion_hosts_allow_https_in
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "ssh_bastion_hosts_allow_bb5_login_nodes" {
-  security_group_id = aws_security_group.ssh_bastion_hosts.id
-  description       = "Allow SSH from BB5 Login nodes"
-  from_port         = 22
-  to_port           = 22
-  ip_protocol       = "tcp"
-  cidr_ipv4         = var.bb5_login_nodes_cidr
-
-  tags = {
-    Name = "ssh_bastion_hosts_allow_bb5_login_nodes"
-  }
-}
-
-resource "aws_vpc_security_group_ingress_rule" "ssh_bastion_hosts_allow_bbpssh" {
-  security_group_id = aws_security_group.ssh_bastion_hosts.id
-  description       = "Allow SSH from BBP SSH Bastion host (Jumphost)"
-  from_port         = 22
-  to_port           = 22
-  ip_protocol       = "tcp"
-  cidr_ipv4         = var.bbpssh_cidr
-
-  tags = {
-    Name = "ssh_bastion_hosts_allow_bbpssh"
-  }
-}
-
 resource "aws_vpc_security_group_ingress_rule" "ssh_bastion_hosts_allow_ssh_vpc_us_east_1" {
   security_group_id = aws_security_group.ssh_bastion_hosts.id
   description       = "Allow SSH from internal"

--- a/subnets-public.tf
+++ b/subnets-public.tf
@@ -37,24 +37,6 @@ resource "aws_network_acl" "public" {
     from_port  = 443
     to_port    = 443
   }
-  # Allow port 22 from BBP SSH Bastion
-  ingress {
-    protocol   = "tcp"
-    rule_no    = 125
-    action     = "allow"
-    cidr_block = var.bbpssh_cidr
-    from_port  = 22
-    to_port    = 22
-  }
-  # Allow port 22 from BB5 Login Nodes
-  ingress {
-    protocol   = "tcp"
-    rule_no    = 130
-    action     = "allow"
-    cidr_block = var.bb5_login_nodes_cidr
-    from_port  = 22
-    to_port    = 22
-  }
   # Deny port 5000 (Brayns) from all other IPs
   ingress {
     protocol   = "tcp"

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -57,27 +57,6 @@ variable "ec_apikey" {
   sensitive = true
 }
 
-variable "bbp_dmz_cidr" {
-  type        = string
-  default     = "192.33.211.0/26"
-  description = "CIDR of the BBP DMZ, containing bbpproxy, bbpssh bastion host and the proxy for SauceLabs"
-  sensitive   = false
-}
-
-variable "bb5_login_nodes_cidr" {
-  type        = string
-  default     = "192.33.194.8/29"
-  description = "CIDR of the network range used by BB5 Login Nodes (bbpv1, bbpv2)"
-  sensitive   = false
-}
-
-variable "bbpssh_cidr" {
-  type        = string
-  default     = "192.33.211.12/32"
-  description = "CIDR of the network range used by SSH Bastion host (BBP SSH Jumphost)"
-  sensitive   = false
-}
-
 variable "core_web_app_docker_image_url" {
   type        = string
   description = "docker image for the core-web-app"


### PR DESCRIPTION
The only interesting thing of this PR is this line https://github.com/openbraininstitute/aws-terraform-deployment/compare/remove_bbp_cidr_ref?expand=1#diff-923ade8e2f77baea4a0ae0cab38c3ba3191a0295985ce28bac3c5959a5bb8073R215