### PR TITLE
Set correct Nexus Delta URL for BlueNaas service

### DIFF
--- a/bluenaas_svc/backend.tf
+++ b/bluenaas_svc/backend.tf
@@ -160,6 +160,10 @@ resource "aws_ecs_task_definition" "bluenaas_ecs_definition" {
           name  = "DEPLOYMENT_ENV"
           value = var.deployment_env
         },
+        {
+          name  = "NEXUS_ROOT_URI"
+          value = var.nexus_delta_uri
+        }
       ]
 
       secrets = [

--- a/bluenaas_svc/variables.tf
+++ b/bluenaas_svc/variables.tf
@@ -59,3 +59,7 @@ variable "internet_access_route_id" {
 variable "bluenaas_service_secrets_arn" {
   type = string
 }
+
+variable "nexus_delta_uri" {
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,8 @@ module "bluenaas_svc" {
 
   keycloak_server_url = "https://${local.primary_domain}/auth/"
 
+  nexus_delta_uri = "https://${module.nexus.nexus_domain_name}/api/nexus/v1"
+
   base_path = "/api/bluenaas"
 }
 


### PR DESCRIPTION
Default value in BlueNaas repo is incorrectly pointing to the production one (which should be fixed separately).
Now it's going to use staging nexus instead.