### PR TITLE
Restrict keycloak service security_groups and network ACLs ingress rules

### DIFF
--- a/cs/keycloak/security_groups.tf
+++ b/cs/keycloak/security_groups.tf
@@ -1,26 +1,38 @@
-# Create Security Group for EFS (Allowing all traffic)
+data "aws_vpc" "main" {
+  id = var.vpc_id
+}
+
 resource "aws_security_group" "efs_sg" {
   name        = "efs-sg"
   description = "Security group for EFS"
   vpc_id      = var.vpc_id
-
-  # Allow all inbound traffic on NFS port (2049) from any source
-  ingress {
-    description = "Allow ingress from anywhere"
-    from_port   = 2049
-    to_port     = 2049
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  tags = {
+    SBO_Billing = "keycloak"
+    Name        = "keycloak_efs_sg"
   }
+}
 
-  # Allow all outbound traffic to any destination
-  egress {
-    description = "Allow egress to anywhere"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_vpc_security_group_egress_rule" "efs_sg_egress" {
+  security_group_id = aws_security_group.efs_sg.id
+  description       = "Allow egress to any destination"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  from_port         = 0
+  to_port           = 0
+
+  tags = {
+    SBO_Billing = "keycloak"
+    Name        = "keycloak_efs_sg"
   }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "efs_sg_ingress" {
+  security_group_id = aws_security_group.efs_sg.id
+  description       = "Allow ingress to NFS port from VPC"
+  cidr_ipv4         = data.aws_vpc.main.cidr_block
+  ip_protocol       = "tcp"
+  from_port         = 2049
+  to_port           = 2049
 
   tags = {
     SBO_Billing = "keycloak"
@@ -43,7 +55,7 @@ resource "aws_vpc_security_group_ingress_rule" "main_subnet_ingress" {
   security_group_id = aws_security_group.main_sg.id
   description       = "Allow everything incoming from the VPC"
   ip_protocol       = -1
-  cidr_ipv4         = "10.0.0.0/16"
+  cidr_ipv4         = data.aws_vpc.main.cidr_block
   from_port         = -1
   to_port           = -1
 

--- a/cs/networking/cs-subnet.tf
+++ b/cs/networking/cs-subnet.tf
@@ -1,4 +1,4 @@
-# Subnets for the SBO core svc
+# Subnets for Keycloak svc
 resource "aws_subnet" "cs_subnet_a" {
   vpc_id                  = var.vpc_id
   availability_zone       = "${data.aws_region.current.name}a"

--- a/cs/networking/network-acls.tf
+++ b/cs/networking/network-acls.tf
@@ -1,44 +1,21 @@
+data "aws_vpc" "main" {
+  id = var.vpc_id
+}
+
 resource "aws_network_acl" "cs_subnet" {
   vpc_id     = var.vpc_id
   subnet_ids = [aws_subnet.cs_subnet_a.id, aws_subnet.cs_subnet_b.id]
+
   # Allow local traffic
   ingress {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = "0.0.0.0/0"
-    # cidr_block = data.terraform_remote_state.common.outputs.vpc_cidr_block
-    from_port = 0
-    to_port   = 0
+    cidr_block = data.aws_vpc.main.cidr_block
+    from_port  = 0
+    to_port    = 0
   }
-  /* # Allow temporarily all
-  ingress {
-    protocol = -1
-    rule_no = 101
-    action = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port = 0
-    to_port = 0
-  }*/
-  # Allow port 8000 from anywhere
-  # TODO limit to just ALB?
-  ingress {
-    protocol   = "tcp"
-    rule_no    = 105
-    action     = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port  = 8000
-    to_port    = 8000
-  }
-  # allow ingress ephemeral ports
-  ingress {
-    protocol   = "tcp"
-    rule_no    = 300
-    action     = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port  = 1024
-    to_port    = 65535
-  }
+
   egress {
     # TODO limit to dockerhub, secretsmanager, nexus...
     protocol   = -1
@@ -48,6 +25,7 @@ resource "aws_network_acl" "cs_subnet" {
     from_port  = 0
     to_port    = 0
   }
+
   tags = {
     Name        = "cs_subnet_acl"
     SBO_Billing = "common"


### PR DESCRIPTION
Almost the same PR as the one I needed to revert but this time I do not modify the description field of the SGs.
By avoiding changing this, the SG does not need to be destroyed and recreated, so I hope it works this time :) 