### PR TITLE
Fix keycloak health check

### DIFF
--- a/cs/keycloak/alb.tf
+++ b/cs/keycloak/alb.tf
@@ -1,7 +1,7 @@
 #  Configure ALB target group
 resource "aws_lb_target_group" "private_keycloak_target_group" {
   name        = "private-keycloak-target-group"
-  port        = 8081
+  port        = var.keycloak_port
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = var.vpc_id
@@ -11,7 +11,7 @@ resource "aws_lb_target_group" "private_keycloak_target_group" {
   }
   health_check {
     path                = "/auth/health"
-    port                = "8081"
+    port                = var.keycloak_management_port
     protocol            = "HTTP"
     interval            = 30
     timeout             = 5

--- a/cs/keycloak/service.tf
+++ b/cs/keycloak/service.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_service" "keycloak_service_terraform" {
   load_balancer {
     target_group_arn = aws_lb_target_group.private_keycloak_target_group.arn
     container_name   = "keycloak-container"
-    container_port   = 8081
+    container_port   = var.keycloak_port
   }
 
   enable_execute_command = true

--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -14,9 +14,15 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
             "memory": 4096,
             "portMappings": [
                 {
-                    "name": "keycloak-container-8081-tcp",
-                    "containerPort": 8081,
-                    "hostPort": 8081,
+                    "name": "keycloak-container-port-tcp",
+                    "containerPort": ${var.keycloak_port},
+                    "hostPort": ${var.keycloak_port},
+                    "protocol": "tcp"
+                },
+                {
+                    "name": "keycloak-management-port-tcp",
+                    "containerPort": ${var.keycloak_management_port},
+                    "hostPort": ${var.keycloak_management_port},
                     "protocol": "tcp"
                 }
             ],
@@ -59,7 +65,7 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
 	        },
 	        {
                     "name": "KC_HTTP_PORT",
-                    "value": "8081"
+                    "value": "${var.keycloak_port}"
 	        },
                 {
                     "name": "KC_PROXY",

--- a/cs/keycloak/variables.tf
+++ b/cs/keycloak/variables.tf
@@ -33,6 +33,14 @@ variable "db_instance_class" {
   type = string
 }
 
+variable "keycloak_management_port" {
+  type = number
+}
+
+variable "keycloak_port" {
+  type = number
+}
+
 # This is the subnet where ECS service will be running
 variable "private_subnets" {
   type = list(string)

--- a/cs/main.tf
+++ b/cs/main.tf
@@ -16,7 +16,9 @@ module "keycloak" {
 
   efs_mt_subnets = module.networking.keycloak_private_subnets
 
-  keycloak_secrets_arn = var.keycloak_secrets_arn
+  keycloak_secrets_arn     = var.keycloak_secrets_arn
+  keycloak_port            = 8081
+  keycloak_management_port = 9000
 
   allowed_source_ip_cidr_blocks = var.allowed_source_ip_cidr_blocks
 }


### PR DESCRIPTION
After the upgrade to v25 the /health endpoint runs on the management port