### PR TITLE
Give staging Keycloak ECS task more resources

### DIFF
--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -9,7 +9,7 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
     operating_system_family = "LINUX"
     cpu_architecture        = "ARM64"
   }
-  container_definitions    = <<TASK_DEFINITION
+  container_definitions = <<TASK_DEFINITION
   [
         {
             "name": "keycloak-container",
@@ -125,8 +125,8 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
         }
     ]
     TASK_DEFINITION
-  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
-  task_role_arn            = aws_iam_role.ecs_task_execution_role.arn
+  execution_role_arn    = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn         = aws_iam_role.ecs_task_execution_role.arn
   volume {
     name = "keycloak-theme-volume"
     efs_volume_configuration {

--- a/production.tfvars
+++ b/production.tfvars
@@ -25,6 +25,5 @@ keycloak_task_size = {
   cpu    = 2048
   memory = 4096
 }
-# TODO: replace tag below with a version tag when the CI is ready
-bluenaas_docker_image_url = "bluebrain/blue-naas-single-cell:latest"
+
 hpc_resource_provisioner_container_version = "latest"

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -20,8 +20,8 @@ bluenaas_task_size = {
   memory = 8192
 }
 keycloak_task_size = {
-  cpu    = 1024
-  memory = 2048
+  cpu    = 2048
+  memory = 4096
 }
 viz_scientific_data_bucket_name            = "important-scientific-data-staging"
 coreservices_public_key                    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDO8QAh2WZ/WcZnNeojPNhadeodMO2l3PssaUFJWfvEFNzkuo5ci7nxb39M2FH6RyFAfqykV/v89KfDIg9K2ebJQZS+x6Enrqm7+ROmZjCdpYkFm7l2NCoKLus92DaPX6k1Tv5hcI76BqWN4nOKQxzb7ziJxFl5wzLgTwnXZvY33dA3Pu6aimksv071KnQ3hJKk6Omx/l7Hv/D7c0tU8vRCUefzHT3TkRpRgTTq+Wd8S0pGSmMB4drk5PiUzEVczxuIfmYGCWV2va6aT34yuMOw/6y2Cr9guCkyR2FkFm7q0MPw0aKGFBwTT05eiEWBWKQQbqi1qMtSwd6tp4qv6crN SSH key for AWS SBO POC"


### PR DESCRIPTION
ALthough it runs, 1 core, 2Gb of memory is not enough to pass the health checks