### PR TITLE
Add deployment env to core-web-app

### DIFF
--- a/core_webapp/core-webapp-container.tf
+++ b/core_webapp/core-webapp-container.tf
@@ -123,6 +123,10 @@ resource "aws_ecs_task_definition" "core_webapp_ecs_definition" {
           value = var.env_DEBUG
         },
         {
+          name  = "NEXT_PUBLIC_DEPLOYMENT_ENV"
+          value = var.env_NEXT_PUBLIC_DEPLOYMENT_ENV
+        },
+        {
           name  = "NEXTAUTH_URL"
           value = var.env_NEXTAUTH_URL
         },
@@ -159,6 +163,10 @@ resource "aws_ecs_task_definition" "core_webapp_ecs_definition" {
         {
           name      = "MAILCHIMP_AUDIENCE_ID"
           valueFrom = "${var.core_webapp_secrets_arn}:MAILCHIMP_AUDIENCE_ID::"
+        },
+        {
+          name      = "MAILCHIMP_API_SERVER"
+          valueFrom = "${var.core_webapp_secrets_arn}:MAILCHIMP_API_SERVER::"
         }
       ]
       logConfiguration = {

--- a/core_webapp/variables.tf
+++ b/core_webapp/variables.tf
@@ -102,3 +102,10 @@ variable "env_NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL" {
   sensitive   = false
   description = "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY environment value for the webapp"
 }
+
+variable "env_NEXT_PUBLIC_DEPLOYMENT_ENV" {
+  default     = "production"
+  type        = string
+  description = "env core-web-app is deployed <staging|production>"
+  sensitive   = false
+}

--- a/core_webapp/variables.tf
+++ b/core_webapp/variables.tf
@@ -104,7 +104,6 @@ variable "env_NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL" {
 }
 
 variable "env_NEXT_PUBLIC_DEPLOYMENT_ENV" {
-  default     = "production"
   type        = string
   description = "env core-web-app is deployed <staging|production>"
   sensitive   = false

--- a/main.tf
+++ b/main.tf
@@ -262,8 +262,9 @@ module "core_webapp" {
   env_DEBUG                               = "true"
   env_NEXTAUTH_URL                        = "https://${local.primary_domain}/app/api/auth"
   env_KEYCLOAK_ISSUER                     = "https://${local.primary_domain}/auth/realms/SBO"
-  env_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY  = "pk_test_51P6uAFFE4Bi50cLlatJIc0fUPsP0jQkaCCJ8TTkIYOOLIrLzxX1M9p1kVD11drNqsF9p7yiaumWJ8UHb3ptJJRXB00y3qjYReV"
+  env_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY  = "pk_test_51QjjHBKGUR5u3ofLgNUOpljnvy27UTTpkhwgsLiwK9xlNjnR7CZfiMjtZWMjgN7GW3eDyzMJ7Z1pIqC9LiwkfQRX00ebb5c9XI"
   env_NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL = "http://${data.terraform_remote_state.common.outputs.private_alb_dns_name}:3000/api/literature"
+  env_NEXT_PUBLIC_DEPLOYMENT_ENV          = var.core_web_app_deployment_env
 }
 
 module "accounting_svc" {

--- a/production.tfvars
+++ b/production.tfvars
@@ -28,3 +28,4 @@ keycloak_task_size = {
 }
 coreservices_public_key                    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDO8QAh2WZ/WcZnNeojPNhadeodMO2l3PssaUFJWfvEFNzkuo5ci7nxb39M2FH6RyFAfqykV/v89KfDIg9K2ebJQZS+x6Enrqm7+ROmZjCdpYkFm7l2NCoKLus92DaPX6k1Tv5hcI76BqWN4nOKQxzb7ziJxFl5wzLgTwnXZvY33dA3Pu6aimksv071KnQ3hJKk6Omx/l7Hv/D7c0tU8vRCUefzHT3TkRpRgTTq+Wd8S0pGSmMB4drk5PiUzEVczxuIfmYGCWV2va6aT34yuMOw/6y2Cr9guCkyR2FkFm7q0MPw0aKGFBwTT05eiEWBWKQQbqi1qMtSwd6tp4qv6crN SSH key for AWS SBO POC"
 hpc_resource_provisioner_container_version = "latest"
+core_web_app_deployment_env                = "production"

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -26,3 +26,5 @@ keycloak_task_size = {
 }
 coreservices_public_key                    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDO8QAh2WZ/WcZnNeojPNhadeodMO2l3PssaUFJWfvEFNzkuo5ci7nxb39M2FH6RyFAfqykV/v89KfDIg9K2ebJQZS+x6Enrqm7+ROmZjCdpYkFm7l2NCoKLus92DaPX6k1Tv5hcI76BqWN4nOKQxzb7ziJxFl5wzLgTwnXZvY33dA3Pu6aimksv071KnQ3hJKk6Omx/l7Hv/D7c0tU8vRCUefzHT3TkRpRgTTq+Wd8S0pGSmMB4drk5PiUzEVczxuIfmYGCWV2va6aT34yuMOw/6y2Cr9guCkyR2FkFm7q0MPw0aKGFBwTT05eiEWBWKQQbqi1qMtSwd6tp4qv6crN SSH key for AWS SBO POC"
 hpc_resource_provisioner_container_version = "latest"
+core_web_app_deployment_env                = "staging"
+

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -62,6 +62,12 @@ variable "core_web_app_docker_image_url" {
   description = "docker image for the core-web-app"
   sensitive   = false
 }
+variable "core_web_app_deployment_env" {
+  default     = "production"
+  type        = string
+  description = "env core-web-app is deployed <staging|production>"
+  sensitive   = false
+}
 
 ### BlueNaaS service ###
 


### PR DESCRIPTION
this variable allow the frontend to enable some features depends on the env or tag specific data based on the deployment
ex: for newsletter we need to tag the subscriber in staging to deal with test users (delete)