### PR TITLE
Serve core web app from /

### DIFF
--- a/core_webapp/core-webapp-load-balancer.tf
+++ b/core_webapp/core-webapp-load-balancer.tf
@@ -9,8 +9,9 @@ resource "aws_lb_target_group" "core_webapp_private" {
   #  create_before_destroy = true
   #}
   health_check {
-    enabled  = true
-    path     = "/app"
+    enabled = true
+    // TODO Replace with a health check endpoint for core web app once implemented
+    path     = "/"
     protocol = "HTTP"
   }
   tags = {
@@ -20,17 +21,11 @@ resource "aws_lb_target_group" "core_webapp_private" {
 
 resource "aws_lb_listener_rule" "private_core_webapp" {
   listener_arn = var.private_alb_https_listener_arn
-  priority     = 200
+  priority     = 1000
 
   action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.core_webapp_private.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["${var.core_webapp_base_path}*"]
-    }
   }
 
   condition {

--- a/core_webapp/variables.tf
+++ b/core_webapp/variables.tf
@@ -40,12 +40,6 @@ variable "core_webapp_docker_image_url" {
   sensitive   = false
 }
 
-variable "core_webapp_base_path" {
-  type        = string
-  description = "The base path for the core webapp"
-  sensitive   = false
-}
-
 variable "route_table_id" {
   type        = string
   description = "route table for private networks"

--- a/main.tf
+++ b/main.tf
@@ -251,7 +251,6 @@ module "core_webapp" {
   private_alb_https_listener_arn       = data.terraform_remote_state.common.outputs.private_alb_https_listener_arn
   aws_region                           = local.aws_region
   core_webapp_docker_image_url         = var.core_web_app_docker_image_url
-  core_webapp_base_path                = "/app"
   route_table_id                       = local.route_table_private_subnets_id
   allowed_source_ip_cidr_blocks        = ["0.0.0.0/0"]
   vpc_cidr_block                       = local.vpc_cidr_block
@@ -259,7 +258,7 @@ module "core_webapp" {
   accounting_base_url                  = "https://${local.primary_domain}${var.accounting_base_path}"
 
   env_DEBUG                               = "true"
-  env_NEXTAUTH_URL                        = "https://${local.primary_domain}/app/api/auth"
+  env_NEXTAUTH_URL                        = "https://${local.primary_domain}/api/auth"
   env_KEYCLOAK_ISSUER                     = "https://${local.primary_domain}/auth/realms/SBO"
   env_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY  = "pk_test_51QjjHBKGUR5u3ofLgNUOpljnvy27UTTpkhwgsLiwK9xlNjnR7CZfiMjtZWMjgN7GW3eDyzMJ7Z1pIqC9LiwkfQRX00ebb5c9XI"
   env_NEXT_PUBLIC_BBS_ML_PRIVATE_BASE_URL = "http://${data.terraform_remote_state.common.outputs.private_alb_dns_name}:3000/api/literature"


### PR DESCRIPTION
The ALB rule path pattern has been removed so that "by default" the requests not matched by the higher priority rules will be handed to core web app, so that it can serve content for the `/`.