### PR TITLE
Temporarily allow HTTP 307 on the core web app health check endpoint

### DIFF
--- a/core_webapp/core-webapp-load-balancer.tf
+++ b/core_webapp/core-webapp-load-balancer.tf
@@ -13,6 +13,8 @@ resource "aws_lb_target_group" "core_webapp_private" {
     // TODO Replace with a health check endpoint for core web app once implemented
     path     = "/"
     protocol = "HTTP"
+    # TODO: Remove 307 when the domain redirect is implemented on AWS ALB level
+    matcher = "200,307"
   }
   tags = {
     SBO_Billing = "core_webapp"


### PR DESCRIPTION
The domain redirect is now enabled on the core web app server itself.

When ALB sends a health check the hostname in the request never matches the "primary" domain so web app responds with redirect. This is a temporary workaround. To be reverted back when domain redirect either is disabled or implemented on AWS ALB level.