### PR TITLE
Add permission for lambda connect to pass roles to ECS task

### DIFF
--- a/on_demand_svc/lambda.tf
+++ b/on_demand_svc/lambda.tf
@@ -30,6 +30,11 @@ data "aws_iam_policy_document" "ws_handler_connect" {
     resources = [aws_iam_role.task_exec.arn]
     effect    = "Allow"
   }
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.task.arn]
+    effect    = "Allow"
+  }
 }
 
 resource "aws_iam_policy" "ws_handler_connect" {

--- a/on_demand_svc/lambda.tf
+++ b/on_demand_svc/lambda.tf
@@ -27,12 +27,7 @@ data "aws_iam_policy_document" "ws_handler_connect" {
   }
   statement {
     actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.task_exec.arn]
-    effect    = "Allow"
-  }
-  statement {
-    actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.task.arn]
+    resources = [aws_iam_role.task_exec.arn, aws_iam_role.task.arn]
     effect    = "Allow"
   }
 }


### PR DESCRIPTION
Why it works without that permission when using ECS on EC2 is still to be investigated.

Separate thank you to @danifr to help debug the issue.