### PR TITLE
Remove TF_VAR_ec_apikey from github workflows

### DIFF
--- a/.github/workflows/auto_deploy_staging.yaml
+++ b/.github/workflows/auto_deploy_staging.yaml
@@ -14,7 +14,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_ec_apikey: ${{ secrets.ELASTIC_CLOUD_API_KEY }} # nexus uses ELASTIC CLOUD
       TF_VAR_ec_apikey2: ${{ secrets.ELASTIC_CLOUD_API_KEY2 }} # Second, new elastic cloud instance of the new AWS org
       TF_VAR_nise_dockerhub_password: ${{ secrets.NISE_DOCKERHUB_PASS }}
 

--- a/.github/workflows/auto_verify_pr.yaml
+++ b/.github/workflows/auto_verify_pr.yaml
@@ -14,7 +14,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_ec_apikey: ${{ secrets.ELASTIC_CLOUD_API_KEY }} # nexus uses ELASTIC CLOUD
       TF_VAR_ec_apikey2: ${{ secrets.ELASTIC_CLOUD_API_KEY2 }} # Second, new elastic cloud instance of the new AWS org
       TF_VAR_nise_dockerhub_password: ${{ secrets.NISE_DOCKERHUB_PASS }}
 

--- a/.github/workflows/auto_verify_tag.yaml
+++ b/.github/workflows/auto_verify_tag.yaml
@@ -11,7 +11,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_ec_apikey: ${{ secrets.ELASTIC_CLOUD_API_KEY }} # nexus uses ELASTIC CLOUD
       TF_VAR_ec_apikey2: ${{ secrets.ELASTIC_CLOUD_API_KEY2 }} # Second, new elastic cloud instance of the new AWS org
       TF_VAR_nise_dockerhub_password: ${{ secrets.NISE_DOCKERHUB_PASS }}
 

--- a/.github/workflows/manual_deploy.yaml
+++ b/.github/workflows/manual_deploy.yaml
@@ -17,7 +17,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VAR_ec_apikey: ${{ secrets.ELASTIC_CLOUD_API_KEY }} # nexus uses ELASTIC CLOUD
       TF_VAR_ec_apikey2: ${{ secrets.ELASTIC_CLOUD_API_KEY2 }} # Second, new elastic cloud instance of the new AWS org
       TF_VAR_nise_dockerhub_password: ${{ secrets.NISE_DOCKERHUB_PASS }}
 


### PR DESCRIPTION
Related:

6c299e48dda657d230bca9832168a91b5e8150df

46ee6d9e200203383218614d21235ad9f40a063e