### PR TITLE
obi-one/obi-generative-gui: allow ephemeral ports

### DIFF
--- a/obi_generative_gui/subnets.tf
+++ b/obi_generative_gui/subnets.tf
@@ -38,6 +38,15 @@ resource "aws_network_acl" "obi_generative_gui_nacl" {
     to_port    = var.container_port
     protocol   = "tcp"
   }
+  # allow ingress to ephemeral ports
+  ingress {
+    rule_no    = 150
+    action     = "allow"
+    cidr_block = data.aws_vpc.main.cidr_block
+    from_port  = 1024
+    to_port    = 65535
+    protocol   = "tcp"
+  }
   egress {
     rule_no    = 200
     action     = "allow"

--- a/obi_one/subnets.tf
+++ b/obi_one/subnets.tf
@@ -38,6 +38,15 @@ resource "aws_network_acl" "obi_one_nacl" {
     to_port    = var.container_port
     protocol   = "tcp"
   }
+  # allow ingress to ephemeral ports
+  ingress {
+    rule_no    = 150
+    action     = "allow"
+    cidr_block = data.aws_vpc.main.cidr_block
+    from_port  = 1024
+    to_port    = 65535
+    protocol   = "tcp"
+  }
   egress {
     rule_no    = 200
     action     = "allow"


### PR DESCRIPTION
Current error:

CannotPullContainerError: pull image manifest has been retried 5 time(s): failed to resolve ref public.ecr.aws/openbraininstitute/obi-one:2025.4.2: failed to do request: Head "https://public.ecr.aws/v2/openbraininstitute/obi-one/manifests/2025.4.2": dial tcp 75.2.101.78:443: i/o timeout
