### PR TITLE
Specify postgres minor version to upgrade to

### DIFF
--- a/cs/keycloak/database.tf
+++ b/cs/keycloak/database.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "keycloak_database" {
   allocated_storage            = 20
   storage_type                 = "gp2"
   engine                       = "postgres"
-  engine_version               = "16"
+  engine_version               = "16.3"
   auto_minor_version_upgrade   = true
   instance_class               = var.db_instance_class
   db_name                      = "keycloak"


### PR DESCRIPTION
If not we get: `Cannot upgrade postgres from 14.12 to 16.6`

From 14.12 (current) we can only upgrade to 16.2