### PR TITLE
Revert "Specify postgres minor version to upgrade to"

### DIFF
--- a/cs/keycloak/database.tf
+++ b/cs/keycloak/database.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "keycloak_database" {
   allocated_storage            = 20
   storage_type                 = "gp2"
   engine                       = "postgres"
-  engine_version               = "16.3"
+  engine_version               = "16"
   auto_minor_version_upgrade   = true
   instance_class               = var.db_instance_class
   db_name                      = "keycloak"


### PR DESCRIPTION
So in the the end I upgraded to 16.3 using the AWS Console In terraform we make sure that the major version is 16

This reverts commit 8d620e8a6574c2dbea552ef48bb245933244b9e6.