### PR TITLE
Set JupyterHub EC2 instance size back to 4xlarge

### DIFF
--- a/production.tfvars
+++ b/production.tfvars
@@ -18,7 +18,7 @@ accounting_svc_docker_image_url           = "public.ecr.aws/openbraininstitute/a
 me_model_analysis_docker_image_url        = "public.ecr.aws/openbraininstitute/me-model-analysis:2025.04.08.1"
 is_nexus_openscience_running              = false
 is_nexus_obp_running                      = true
-jupyterhub_ec2_type                       = "c7i.xlarge"
+jupyterhub_ec2_type                       = "c7i.4xlarge"
 
 # TODO: replace tag below with a version tag when the CI is ready
 bluenaas_docker_image_url = "bluebrain/blue-naas-single-cell:latest"


### PR DESCRIPTION
Downsize was done d4a162a7cba34bfe8709636c8a0a5a3e45d4b9d1 
but we want to keep on using 4xlarge at least for one more week