### PR TITLE
entitycore: bump to 2025.5.0 in staging

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -48,7 +48,7 @@ hpc_resource_provisioner_scratch_bucket       = ""
 
 entitycore_svc_s3_bucket_name            = "entitycore-data-staging"
 entitycore_svc_s3_bucket_allowed_origins = ["*"]
-entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
+entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.5.0"
 
 obi_one_docker_image_url            = "public.ecr.aws/openbraininstitute/obi-one:2025.5.1"
 obi_generative_gui_docker_image_url = "public.ecr.aws/openbraininstitute/obi-generative-gui:2025.5.0"


### PR DESCRIPTION
Tag published to https://gallery.ecr.aws/openbraininstitute/entitycore