### PR TITLE
Only specify portgresql major DB version

### DIFF
--- a/ml/variables.tf
+++ b/ml/variables.tf
@@ -165,7 +165,7 @@ variable "rds_engine" {
 
 variable "rds_version" {
   description = "version of the rds database."
-  default     = "16.4"
+  default     = "16"
 }
 
 variable "rds_instance_class" {


### PR DESCRIPTION
Otherwise terraform will try to downgrade if a newer sec update was applied.

```
│ Error: updating RDS DB Instance (ml-rds-postgres): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: abc11bca-ba6c-4782-ae06-5145bbb1b8e0, api error InvalidParameterCombination: Cannot upgrade postgres from 16.8 to 16.4
│ 
│   with module.ml.module.ml_rds_postgres.module.db_instance.aws_db_instance.this[0],
│   on .terraform/modules/ml.ml_rds_postgres/modules/db_instance/main.tf line 30, in resource "aws_db_instance" "this":
│   30: resource "aws_db_instance" "this" {
```