### PR TITLE
Remove awsemf exporter from otel config

### DIFF
--- a/cs/keycloak/otel-agent-config.yaml.tmpl
+++ b/cs/keycloak/otel-agent-config.yaml.tmpl
@@ -38,6 +38,6 @@ service:
     metrics:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [awsemf, prometheusremotewrite]
+      exporters: [prometheusremotewrite]
 
   extensions: [health_check, sigv4auth]


### PR DESCRIPTION
Removing it will stop sending keycloak metrics to CloudWatch. We saw an increase of CloudWatch cost and we only need those metrics in Prometheus 

More info: https://github.com/openbraininstitute/neurodamus/issues/279#issuecomment-2965608817