### PR TITLE
entitycore: bump to 2025.6.5 in prod

### DIFF
--- a/production.tfvars
+++ b/production.tfvars
@@ -53,7 +53,7 @@ hpc_resource_provisioner_scratch_bucket       = ""
 
 entitycore_svc_s3_bucket_name            = "entitycore-data-production"
 entitycore_svc_s3_bucket_allowed_origins = ["www.openbraininstitute.org"]
-entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
+entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.6.5"
 
 obi_one_docker_image_url            = "public.ecr.aws/openbraininstitute/obi-one:2025.6.5"
 obi_generative_gui_docker_image_url = "public.ecr.aws/openbraininstitute/obi-generative-gui:2025.5.4"


### PR DESCRIPTION
This PR will deploy the same version of entitycore in staging to production.
It will require a manual drop of the db in production (there is a short script containing the commands for that)

Still draft, because we are probably going to make a new release before.