### PR TITLE
Revert "Fix missing double quote"

### DIFF
--- a/cs/jupyterhub/jupyterhub_config.sh.tpl
+++ b/cs/jupyterhub/jupyterhub_config.sh.tpl
@@ -57,7 +57,7 @@ do
   sudo tljh-config add-item users.admin jupyter-$${USERNAME}
 done
 
-JUPYTERHUB_ADMINS_SET=$(printf "'%s', " "${JUPYTERHUB_ADMINS}")
+JUPYTERHUB_ADMINS_SET=$(printf "'%s', " ${JUPYTERHUB_ADMINS})
 JUPYTERHUB_ADMINS_SET="$${JUPYTERHUB_ADMINS_SET%, }"  # remove trailing comma and space
 
 # Setup Keycloak as a GenericOAuthenticator


### PR DESCRIPTION
Let bash split the list of users into separate words

This reverts commit cfc69ec8d4dee6136b2eb2837cbd36e016a00447.