### PR TITLE
Scale down small scale simulator, optimise provider strategy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -274,10 +274,11 @@ module "small_scale_simulator" {
   entitycore_url      = "https://${local.primary_domain}/api/entitycore"
   keycloak_server_url = "https://${local.primary_domain}/auth/"
 
-  api_task_size                  = var.small_scale_simulator_api_task_size
-  worker_task_size               = var.small_scale_simulator_worker_task_size
-  worker_autoscaler_min_capacity = var.small_scale_simulator_worker_autoscaler_min_capacity
-  num_workers                    = var.small_scale_simulator_num_workers
+  api_task_size                     = var.small_scale_simulator_api_task_size
+  worker_task_size                  = var.small_scale_simulator_worker_task_size
+  worker_autoscaler_min_capacity    = var.small_scale_simulator_worker_autoscaler_min_capacity
+  worker_capacity_provider_strategy = var.small_scale_simulator_worker_capacity_provider_strategy
+  num_workers                       = var.small_scale_simulator_num_workers
 }
 
 module "github_ami_build_role" {

--- a/production.tfvars
+++ b/production.tfvars
@@ -29,7 +29,7 @@ bluenaas_task_size = {
 
 small_scale_simulator_api_docker_image_url           = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2025.07.04.1"
 small_scale_simulator_worker_docker_image_url        = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2025.07.04.1"
-small_scale_simulator_worker_autoscaler_min_capacity = 4
+small_scale_simulator_worker_autoscaler_min_capacity = 1
 small_scale_simulator_num_workers                    = 12
 small_scale_simulator_worker_task_size = {
   cpu    = 16384
@@ -39,6 +39,10 @@ small_scale_simulator_api_task_size = {
   cpu    = 1024
   memory = 2048
 }
+small_scale_simulator_worker_capacity_provider_strategy = [
+  { capacity_provider = "FARGATE", weight = 25 },
+  { capacity_provider = "FARGATE_SPOT", weight = 75 }
+]
 
 virtual_lab_manager_task_size = {
   cpu    = 1024

--- a/small_scale_simulator/ecs.tf
+++ b/small_scale_simulator/ecs.tf
@@ -477,14 +477,12 @@ resource "aws_ecs_service" "worker" {
     ignore_changes = [desired_count]
   }
 
-  capacity_provider_strategy {
-    capacity_provider = "FARGATE"
-    weight            = 25
-  }
-
-  capacity_provider_strategy {
-    capacity_provider = "FARGATE_SPOT"
-    weight            = 75
+  dynamic "capacity_provider_strategy" {
+    for_each = var.worker_capacity_provider_strategy
+    content {
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+    }
   }
 
   network_configuration {

--- a/small_scale_simulator/variables.tf
+++ b/small_scale_simulator/variables.tf
@@ -100,3 +100,12 @@ variable "worker_autoscaler_min_capacity" {
 
   description = "Minimum number of worker nodes requested from capacity provider"
 }
+
+variable "worker_capacity_provider_strategy" {
+  type = list(object({
+    capacity_provider = string # Valid values: FARGATE, FARGATE_SPOT
+    weight            = number
+  }))
+
+  description = "Capacity provider strategy for worker service"
+}

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -31,7 +31,7 @@ bluenaas_task_size = {
 
 small_scale_simulator_api_docker_image_url           = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-staging"
 small_scale_simulator_worker_docker_image_url        = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-staging"
-small_scale_simulator_worker_autoscaler_min_capacity = 2
+small_scale_simulator_worker_autoscaler_min_capacity = 1
 small_scale_simulator_num_workers                    = 4
 small_scale_simulator_worker_task_size = {
   cpu    = 4096
@@ -41,6 +41,9 @@ small_scale_simulator_api_task_size = {
   cpu    = 256
   memory = 512
 }
+small_scale_simulator_worker_capacity_provider_strategy = [
+  { capacity_provider = "FARGATE_SPOT", weight = 100 }
+]
 
 virtual_lab_manager_task_size = {
   cpu    = 512

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -149,6 +149,15 @@ variable "small_scale_simulator_worker_autoscaler_min_capacity" {
   description = "Minimum number of worker nodes requested from capacity provider for small scale simulator"
 }
 
+variable "small_scale_simulator_worker_capacity_provider_strategy" {
+  type = list(object({
+    capacity_provider = string # Valid values: FARGATE, FARGATE_SPOT
+    weight            = number
+  }))
+
+  description = "Capacity provider strategy for worker service"
+}
+
 
 ### Virtual Lab Manager service ###
 


### PR DESCRIPTION
This change parameterises capacity provider strategy so that we can exclusively use SPOT instances in staging, while combining SPOT + ON-DEMAND instances in production (so that there is no chance that amazon can recall all workers in prod).