### PR TITLE
Scale down staging Keycloak ECS task to 1 cpu 2Gb or RAM

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -51,8 +51,8 @@ virtual_lab_manager_task_size = {
 }
 
 keycloak_task_size = {
-  cpu    = 2048
-  memory = 4096
+  cpu    = 1024
+  memory = 2048
 }
 coreservices_public_key                    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDO8QAh2WZ/WcZnNeojPNhadeodMO2l3PssaUFJWfvEFNzkuo5ci7nxb39M2FH6RyFAfqykV/v89KfDIg9K2ebJQZS+x6Enrqm7+ROmZjCdpYkFm7l2NCoKLus92DaPX6k1Tv5hcI76BqWN4nOKQxzb7ziJxFl5wzLgTwnXZvY33dA3Pu6aimksv071KnQ3hJKk6Omx/l7Hv/D7c0tU8vRCUefzHT3TkRpRgTTq+Wd8S0pGSmMB4drk5PiUzEVczxuIfmYGCWV2va6aT34yuMOw/6y2Cr9guCkyR2FkFm7q0MPw0aKGFBwTT05eiEWBWKQQbqi1qMtSwd6tp4qv6crN SSH key for AWS SBO POC"
 hpc_resource_provisioner_container_version = "latest"


### PR DESCRIPTION
For https://github.com/openbraininstitute/INFRA/issues/222

Change was applied in https://github.com/openbraininstitute/aws-terraform-deployment/actions/runs/16294878178

All good, staging keycloak task is now up and running with the reduced size. I will monitor the performance during the coming days. Maybe we can adjust prod's size too.
