### PR TITLE
Fix aws_s3_internal_bucket in entitycore

### DIFF
--- a/entitycore_svc/backend.tf
+++ b/entitycore_svc/backend.tf
@@ -144,9 +144,25 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
           value = var.db_username
         },
         {
-          name  = "S3_BUCKET_NAME"
-          value = var.s3_bucket_name
-        }
+          name  = "S3_BUCKET_NAME" # for backward compatibility
+          value = var.aws_s3_internal_bucket
+        },
+        {
+          name  = "AWS_S3_INTERNAL_BUCKET"
+          value = var.aws_s3_internal_bucket
+        },
+        {
+          name  = "AWS_S3_INTERNAL_REGION"
+          value = var.aws_s3_internal_region
+        },
+        {
+          name  = "AWS_S3_OPEN_BUCKET"
+          value = var.aws_s3_open_bucket
+        },
+        {
+          name  = "AWS_S3_OPEN_REGION"
+          value = var.aws_s3_open_region
+        },
       ]
 
       secrets = [

--- a/entitycore_svc/policies.tf
+++ b/entitycore_svc/policies.tf
@@ -37,8 +37,8 @@ resource "aws_iam_policy" "s3_access" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::${var.s3_bucket_name}",
-          "arn:aws:s3:::${var.s3_bucket_name}/*"
+          "arn:aws:s3:::${var.aws_s3_internal_bucket}",
+          "arn:aws:s3:::${var.aws_s3_internal_bucket}/*"
         ]
       }
     ]

--- a/entitycore_svc/s3.tf
+++ b/entitycore_svc/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "entitycore" {
-  bucket = var.s3_bucket_name
+  bucket = var.aws_s3_internal_bucket
 
   tags = {
     Name            = "entitycore-storage"

--- a/entitycore_svc/variables.tf
+++ b/entitycore_svc/variables.tf
@@ -47,11 +47,6 @@ variable "entitycore_service_secrets_arn" {
   type = string
 }
 
-variable "s3_bucket_name" {
-  description = "S3 bucket name in which entitycore data lives (for backward compatibility)."
-  type        = string
-}
-
 variable "aws_s3_internal_bucket" {
   description = "S3 bucket name in which entitycore data lives."
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -471,7 +471,6 @@ module "entitycore_svc" {
     "https://staging.openbraininstitute.org/auth/realms/SBO/"
   )
 
-  s3_bucket_name            = var.entitycore_svc_s3_bucket_name # for backward compatibility
   s3_bucket_allowed_origins = var.entitycore_svc_s3_bucket_allowed_origins
   aws_s3_internal_bucket    = var.entitycore_svc_aws_s3_internal_bucket
   aws_s3_internal_region    = var.entitycore_svc_aws_s3_internal_region

--- a/production.tfvars
+++ b/production.tfvars
@@ -73,7 +73,6 @@ sbo_infrastructureassets_bucket               = "s3://sboinfrastructureassets"
 hpc_resource_provisioner_containers_bucket    = ""
 hpc_resource_provisioner_scratch_bucket       = ""
 
-entitycore_svc_s3_bucket_name            = "entitycore-data-production" # for backward compatibility
 entitycore_svc_aws_s3_internal_bucket    = "entitycore-data-production"
 entitycore_svc_aws_s3_internal_region    = "us-east-1"
 entitycore_svc_aws_s3_open_bucket        = "openbluebrain"

--- a/sandbox-hpc.tfvars
+++ b/sandbox-hpc.tfvars
@@ -43,7 +43,7 @@ sbo_infrastructureassets_bucket               = "s3://sboinfrastructureassets-sa
 hpc_resource_provisioner_containers_bucket    = "s3://sboinfrastructureassets-sandbox/containers"
 hpc_resource_provisioner_scratch_bucket       = "s3://sbosandbox-lec3cn"
 
-entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
+entitycore_svc_image_url = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
 
 obi_one_docker_image_url            = "public.ecr.aws/openbraininstitute/obi-one:2025.4.2"
 obi_generative_gui_docker_image_url = "public.ecr.aws/openbraininstitute/obi-generative-gui:2025.4.5"

--- a/sandbox-hpc.tfvars
+++ b/sandbox-hpc.tfvars
@@ -43,8 +43,6 @@ sbo_infrastructureassets_bucket               = "s3://sboinfrastructureassets-sa
 hpc_resource_provisioner_containers_bucket    = "s3://sboinfrastructureassets-sandbox/containers"
 hpc_resource_provisioner_scratch_bucket       = "s3://sbosandbox-lec3cn"
 
-entitycore_svc_s3_bucket_name            = "entitycore-data-staging"
-entitycore_svc_s3_bucket_allowed_origins = ["www.openbraininstitute.org"]
 entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
 
 obi_one_docker_image_url            = "public.ecr.aws/openbraininstitute/obi-one:2025.4.2"

--- a/sandbox-nse.tfvars
+++ b/sandbox-nse.tfvars
@@ -44,7 +44,6 @@ hpc_resource_provisioner_sbo_nexusdata_bucket = "s3://sbonexusdata-sandbox"
 hpc_resource_provisioner_containers_bucket    = "s3://sboinfrastructureassets-sandbox/containers"
 hpc_resource_provisioner_scratch_bucket       = "s3://sbosandbox-lec3cn"
 
-entitycore_svc_s3_bucket_name = "entitycore-data-sandbox-nse-test"
 entitycore_svc_image_url      = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
 
 obi_one_docker_image_url            = "public.ecr.aws/openbraininstitute/obi-one:2025.4.2"

--- a/sandbox-nse.tfvars
+++ b/sandbox-nse.tfvars
@@ -44,7 +44,7 @@ hpc_resource_provisioner_sbo_nexusdata_bucket = "s3://sbonexusdata-sandbox"
 hpc_resource_provisioner_containers_bucket    = "s3://sboinfrastructureassets-sandbox/containers"
 hpc_resource_provisioner_scratch_bucket       = "s3://sbosandbox-lec3cn"
 
-entitycore_svc_image_url      = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
+entitycore_svc_image_url = "public.ecr.aws/openbraininstitute/entitycore:2025.4.2"
 
 obi_one_docker_image_url            = "public.ecr.aws/openbraininstitute/obi-one:2025.4.2"
 obi_generative_gui_docker_image_url = "public.ecr.aws/openbraininstitute/obi-generative-gui:2025.4.5"

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -69,7 +69,6 @@ sbo_infrastructureassets_bucket               = "s3://sboinfrastructureassets-st
 hpc_resource_provisioner_containers_bucket    = ""
 hpc_resource_provisioner_scratch_bucket       = ""
 
-entitycore_svc_s3_bucket_name            = "entitycore-data-staging" # for backward compatibility
 entitycore_svc_aws_s3_internal_bucket    = "entitycore-data-staging"
 entitycore_svc_aws_s3_internal_region    = "us-east-1"
 entitycore_svc_aws_s3_open_bucket        = "openbluebrain"

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -234,11 +234,6 @@ variable "sbo_infrastructureassets_bucket" {
 }
 
 ### entitycore ###
-variable "entitycore_svc_s3_bucket_name" {
-  type        = string
-  description = "S3 bucket name in which entitycore data lives (for backward compatibility)."
-}
-
 variable "entitycore_svc_aws_s3_internal_bucket" {
   type        = string
   description = "S3 bucket name in which entitycore data lives."


### PR DESCRIPTION
- Add the new env variables, keep S3_BUCKET_NAME for the moment
- Remove internal variable s3_bucket_name used only in terraform