### PR TITLE
Replace dockerhub registry images by other container registries

### DIFF
--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
   container_definitions = jsonencode([
     {
       name      = "keycloak-container"
-      image     = "keycloak/keycloak:26.2.4"
+      image     = "quay.io/keycloak/keycloak:26.2.4"
       cpu       = var.keycloak_task_size.cpu
       memory    = var.keycloak_task_size.memory
       command   = ["start"]

--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -183,7 +183,7 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
     },
     {
       name      = "keycloak-otel-agent-config"
-      image     = "bash"
+      image     = "public.ecr.aws/docker/library/bash:alpine3.22"
       essential = false
       command = [
         "sh",


### PR DESCRIPTION
Unfortunately we cannot rely on unauthenticated pulls from docker hub:

```
CannotPullContainerError: pull image manifest has been retried 7 time(s): httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/bash/manifests/sha256:6a3e1c2ddbdee552cd69ad8244eee84ad6cc00049c338f700ef5ef247be16f7b: 429 Too Many Requests - Server message: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

So let's use different registries that are not that restrictive.