### PR TITLE
Fix keycloak container healthcheck command

### DIFF
--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -34,11 +34,11 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
       healthcheck = {
         command = [
           "CMD-SHELL",
-          "exec 3<>/dev/tcp/127.0.0.1/${var.keycloak_management_port};echo -e 'GET /health/ready HTTP/1.1\r\nhost: http://localhost\r\nConnection: close\r\n\r\n' >&3;if [ $? -eq 0 ]; then echo 'Healthcheck Successful';exit 0;else echo 'Healthcheck Failed';exit 1;fi;"
+          "[ -f /tmp/HealthCheck.java ] || echo 'public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { java.net.URI uri = java.net.URI.create(args[0]); System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)uri.toURL().openConnection()).getResponseCode() ? 0 : 1); } }' > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:${var.keycloak_management_port}/auth/health/live"
         ]
-        interval    = 30
+        interval    = 10
         timeout     = 5
-        startPeriod = 120
+        startPeriod = 150
         retries     = 3
       }
       environment = [


### PR DESCRIPTION
Current health check leaves this error on the keycloak logs (every 30s :dead: ):
```
August 05, 2025 at 09:35
2025-08-05 07:35:50,090 ERROR [io.quarkus.vertx.http.runtime.QuarkusErrorHandler] (vert.x-eventloop-thread-0) HTTP Request to /health/ready failed, error id: 77a9819e-4ad6-4589-a478-9cd00597e382-13822: io.vertx.core.VertxException: For HTTP/1.x requests, the 'Host' header is required
keycloak-container
August 05, 2025 at 09:35
2025-08-05 07:35:20,083 ERROR [io.quarkus.vertx.http.runtime.QuarkusErrorHandler] (vert.x-eventloop-thread-0) HTTP Request to /health/ready failed, error id: 77a9819e-4ad6-4589-a478-9cd00597e382-13821: io.vertx.core.VertxException: For HTTP/1.x requests, the 'Host' header is required
keycloak-container
August 05, 2025 at 09:34
2025-08-05 07:34:50,083 ERROR [io.quarkus.vertx.http.runtime.QuarkusErrorHandler] (vert.x-eventloop-thread-0) HTTP Request to /health/ready failed, error id: 77a9819e-4ad6-4589-a478-9cd00597e382-13820: io.vertx.core.VertxException: For HTTP/1.x requests, the 'Host' header is required
keycloak-container
August 05, 2025 at 09:34
2025-08-05 07:34:20,083 ERROR [io.quarkus.vertx.http.runtime.QuarkusErrorHandler] (vert.x-eventloop-thread-0) HTTP Request to /health/ready failed, error id: 77a9819e-4ad6-4589-a478-9cd00597e382-13819: io.vertx.core.VertxException: For HTTP/1.x requests, the 'Host' header is required
keycloak-container
```

So this is a different way of doing the same and avoiding the error :)

PS: I stole the code from https://gist.github.com/sarath-soman/5d9aec06953bbd0990c648605d4dba07?permalink_comment_id=5559953#gistcomment-5559953 :sisi: