### PR TITLE
Tweak keycloak target_group and task definion health checks

### DIFF
--- a/cs/keycloak/alb.tf
+++ b/cs/keycloak/alb.tf
@@ -10,14 +10,14 @@ resource "aws_lb_target_group" "private_keycloak_target_group" {
     SBO_Billing = "keycloak"
   }
   health_check {
-    path                = "/auth/health"
+    path                = "/auth/health/ready"
     port                = var.keycloak_management_port
     protocol            = "HTTP"
-    interval            = 30
+    interval            = 60
     timeout             = 5
     healthy_threshold   = 2
     unhealthy_threshold = 2
-    matcher             = "200-399"
+    matcher             = "200"
   }
 }
 

--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
         ]
         interval    = 10
         timeout     = 5
-        startPeriod = 180
+        startPeriod = 90
         retries     = 3
       }
       environment = [


### PR DESCRIPTION
From time to time the target_group health_check fails althught the container seems healthy.