### PR TITLE
Configure CORS origins for obi-one (to allow dev env)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -476,7 +476,7 @@ module "obi_one" {
 
   cors_origins = concat(
     ["https://${local.primary_domain}"],
-    var.is_staging ? ["http://localhost:3000", "https://dev.openbraininstitute.org"] : []
+    var.is_staging ? ["http://localhost:3000", "http://127.0.0.1:3000", "https://dev.openbraininstitute.org"] : []
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -473,6 +473,11 @@ module "obi_one" {
   docker_image_url = var.obi_one_docker_image_url
 
   task_size = var.obi_one_task_size
+
+  cors_origins = concat(
+    ["https://${local.primary_domain}"],
+    var.is_staging ? ["http://localhost:3000", "https://dev.openbraininstitute.org"] : []
+  )
 }
 
 module "obi_generative_gui" {

--- a/obi_one/backend.tf
+++ b/obi_one/backend.tf
@@ -89,6 +89,10 @@ resource "aws_ecs_task_definition" "obi_one_ecs_definition" {
           value = "false"
         },
         {
+          name  = "CORS_ORIGINS"
+          value = jsonencode(var.cors_origins)
+        },
+        {
           name  = "KEYCLOAK_URL"
           value = var.keycloak_url
         },

--- a/obi_one/variables.tf
+++ b/obi_one/variables.tf
@@ -52,3 +52,8 @@ variable "task_size" {
 
   description = "CPU and memory limit for ECS task (number or string format)"
 }
+
+variable "cors_origins" {
+  description = "CORS origins"
+  type        = list(string)
+}


### PR DESCRIPTION
This allows dev environment to access staging obi-one deployment as well as tightens up the security a bit as in the default CORS configuration cross-environment access is allowed, see https://github.com/openbraininstitute/obi-one/blob/main/app/config.py#L23 this change enables isolation between production and staging/dev environments.