### PR TITLE
Remove explicit env var declaration for AWS_REGION in lambda fn

### DIFF
--- a/small_scale_simulator/lambda.tf
+++ b/small_scale_simulator/lambda.tf
@@ -132,7 +132,6 @@ resource "aws_lambda_function" "batch_worker" {
   environment {
     variables = {
       ECS_CLUSTER_NAME = aws_ecs_cluster.main.name
-      AWS_REGION       = var.aws_region
     }
   }
 


### PR DESCRIPTION
It is already provided by the AWS runtime environment.