### PR TITLE
Small scale sim: fix provisioner lambda permissions

### DIFF
--- a/small_scale_simulator/lambda.tf
+++ b/small_scale_simulator/lambda.tf
@@ -56,13 +56,16 @@ resource "aws_iam_policy" "batch_worker_lambda_policy" {
       {
         Effect = "Allow"
         Action = [
-          "ecs:ListTasks",
+          "ecs:ListTasks"
+        ]
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.main.name}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
           "ecs:DescribeTasks"
         ]
-        Resource = [
-          "arn:aws:ecs:${var.aws_region}:*:cluster/${aws_ecs_cluster.main.name}",
-          "arn:aws:ecs:${var.aws_region}:*:task/*"
-        ]
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task/*"
         Condition = {
           StringEquals = {
             "ecs:cluster" = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.main.name}"


### PR DESCRIPTION
The issue was that ecs:ListTasks operates on cluster resources, not task resources: so this splits the permissions and fixes ARNs.