### PR TITLE
Small scale simulator: tweak task provisioning

### DIFF
--- a/small_scale_simulator/ecs.tf
+++ b/small_scale_simulator/ecs.tf
@@ -334,6 +334,10 @@ resource "aws_ecs_task_definition" "api" {
           value = "aws"
         },
         {
+          name  = "METRICS_INTERVAL"
+          value = "10"
+        },
+        {
           name  = "METRICS_AWS_REGION"
           value = var.aws_region
         }

--- a/small_scale_simulator/lambda_function.py
+++ b/small_scale_simulator/lambda_function.py
@@ -39,11 +39,13 @@ def handler(event, context):
                 Dimensions=[{"Name": "QueueName", "Value": queue_name}],
                 StartTime=datetime.utcnow() - timedelta(minutes=2),
                 EndTime=datetime.utcnow(),
-                Period=60,  # 1 minute
+                Period=15,  # 15 seconds
                 Statistics=["Minimum"],
             )
 
             if response["Datapoints"]:
+                print("Datapoints:")
+                print(response["Datapoints"])
                 # Get the most recent datapoint
                 latest_datapoint = max(
                     response["Datapoints"], key=lambda x: x["Timestamp"]


### PR DESCRIPTION
This is mostly about increasing provisioner efficiency: shortening reaction time and minimising chances of duplicate worker deployments.

Changes:
1. Push queue length to CloudWatch with shorter interval (30 s -> 10 s)
2. Use shorter aggregation period when getting metrics in the provisioner lambda
3. Add "_provisioner" prefix to lambda function name to be more explicit about its purpose.