### PR TITLE
Add mount_extra_options in obi_one_v2 and enable S3 metrics in entitycore bucket

### DIFF
--- a/entitycore_svc/s3.tf
+++ b/entitycore_svc/s3.tf
@@ -81,3 +81,8 @@ resource "aws_s3_bucket_policy" "prevent_delete" {
     ]
   })
 }
+
+resource "aws_s3_bucket_metric" "entitycore-metrics" {
+  bucket = aws_s3_bucket.entitycore.id
+  name   = "EntireBucket"
+}

--- a/main.tf
+++ b/main.tf
@@ -586,6 +586,7 @@ module "obi_one_v2" {
       volume_name           = "public-data"
       volume_host_path      = "/aws_s3_internal/public/"
       volume_container_path = "/aws_s3_internal/public/"
+      mount_extra_options   = ""
     },
     {
       bucket_name           = var.entitycore_svc_aws_s3_open_bucket
@@ -594,6 +595,7 @@ module "obi_one_v2" {
       volume_name           = "open-data"
       volume_host_path      = "/aws_s3_open/"
       volume_container_path = "/aws_s3_open/"
+      mount_extra_options   = "--no-sign-request"
     },
   ]
 }

--- a/obi_one_v2/ec2_ecs_user_data.sh
+++ b/obi_one_v2/ec2_ecs_user_data.sh
@@ -48,7 +48,14 @@ AssertPathIsDirectory=$MOUNT_DIR
 Type=forking
 User=root
 Group=root
-ExecStart=/bin/mount-s3 --read-only --allow-other "${cfg.bucket_name}" --region "${cfg.bucket_region}" --prefix "${cfg.bucket_prefix}" "$MOUNT_DIR"
+ExecStart=/bin/mount-s3 \
+  --read-only \
+  --allow-other \
+  --region "${cfg.bucket_region}" \
+  --prefix "${cfg.bucket_prefix}" \
+  ${cfg.mount_extra_options} \
+  "${cfg.bucket_name}" \
+  "$MOUNT_DIR"
 ExecStop=/usr/bin/fusermount -u "$MOUNT_DIR"
 
 [Install]

--- a/obi_one_v2/variables.tf
+++ b/obi_one_v2/variables.tf
@@ -81,6 +81,7 @@ variable "mount_buckets" {
     volume_name           = string # Name of the volume to be mounted
     volume_host_path      = string # Path of the mounted volume on the host, should be set to /{storage_type}/{bucket_prefix}
     volume_container_path = string # Path of the mounted volume in the container, should be set to /{storage_type}/{bucket_prefix}
+    mount_extra_options   = string # Additional options to pass to mount-s3
   }))
   validation {
     condition = alltrue([


### PR DESCRIPTION
- Add mount_extra_options in obi_one_v2, because mounting public data requires `--no-sign-request`
- Enable S3 metrics in entitycore bucket, so they should become visible in cloudwatch in https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~()&query=~'*7bAWS*2fS3*2cBucketName*2cFilterId*7d
