### PR TITLE
obi_one_v2: increase EC2 instance for performance tests

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -91,12 +91,19 @@ obi_one_task_size = {
 }
 obi_generative_gui_docker_image_url = "public.ecr.aws/openbraininstitute/obi-generative-gui:2025.5.4"
 
-obi_one_v2_ec2_instance_type = "t3.small" # vCPUs: 2, Memory: 2 GiB
+# TODO: reduce instance type after performance tests
+obi_one_v2_ec2_instance_type = "t3.large" # vCPUs: 2, Memory: 8 GiB
 obi_one_v2_ecs_task_size = {
   cpu    = 1024
-  memory = 1024 # need to leave some free memory for new deployments
+  memory = 7168 # need to leave some free memory for new deployments
   tmpfs  = 512
 }
+# obi_one_v2_ec2_instance_type = "t3.small" # vCPUs: 2, Memory: 2 GiB
+# obi_one_v2_ecs_task_size = {
+#   cpu    = 1024
+#   memory = 1024 # need to leave some free memory for new deployments
+#   tmpfs  = 512
+# }
 
 # CoreWebApp s3 and CloudFront configuration
 core_webapp_s3_bucket_name = "core-webapp-static-assets-staging"


### PR DESCRIPTION
Use t3.large instead of t3.small for performing circuit extraction.
This can be useful also to check if there is any variation in the S3/EFS throughput, see https://github.com/openbraininstitute/prod-platform-architecture/issues/142

The code now fails with O1 circuit with:
```
  File "h5py/_selector.pyx", line 368, in h5py._selector.Reader.read
  File "h5py/_selector.pyx", line 342, in h5py._selector.Reader.make_array
numpy.core._exceptions._ArrayMemoryError: Unable to allocate 3.03 GiB for an array with shape (407127134,) and data type uint64
```