### PR TITLE
Entitycore s3 lifecycle

### DIFF
--- a/entitycore_svc/s3.tf
+++ b/entitycore_svc/s3.tf
@@ -86,3 +86,19 @@ resource "aws_s3_bucket_metric" "entitycore-metrics" {
   bucket = aws_s3_bucket.entitycore.id
   name   = "EntireBucket"
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "entitycore" {
+  bucket = aws_s3_bucket.entitycore.id
+
+  rule {
+    id     = "remove-old-versions"
+    status = "Enabled"
+    filter {
+      prefix = ""
+    }
+    noncurrent_version_expiration {
+      noncurrent_days           = 90
+      newer_noncurrent_versions = 3
+    }
+  }
+}

--- a/entitycore_svc/s3.tf
+++ b/entitycore_svc/s3.tf
@@ -71,8 +71,8 @@ resource "aws_s3_bucket_policy" "prevent_delete" {
       },
       {
         Sid       = "PreventLifecycleModification"
-        Effect    = "Deny"
-        Principal = "*"
+        Effect    = "Allow"
+        Principal = { "AWS" : "arn:aws:iam::992382665735:user/admin" }
         Action = [
           "s3:PutLifecycleConfiguration"
         ]


### PR DESCRIPTION
Previously, setting the PreventLifecycleModification policy to "Allow" was denied because the Principal was set to "*"; this is not allowed if public access to the bucket is blocked (specifically: "Block public and cross-account access to buckets and objects through any public bucket or access point policies").

By setting this policy to allow lifecycle modifications by the user that runs terraform, the change will go through and then be followed by the new lifecycle rule.