### PR TITLE
Automatically refresh EC2 when the template is updated

### DIFF
--- a/cells_svc/cell-svc-container.tf
+++ b/cells_svc/cell-svc-container.tf
@@ -532,7 +532,7 @@ resource "aws_autoscaling_group" "cells_ecs_autoscaling_group" {
 
   launch_template {
     id      = aws_launch_template.cells_svc_ec2_launch_template.id
-    version = "$Latest"
+    version = aws_launch_template.cells_svc_ec2_launch_template.latest_version
   }
 
   instance_refresh { strategy = "Rolling" }

--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -532,7 +532,7 @@ resource "aws_autoscaling_group" "obi_one_v2_ecs_autoscaling_group" {
 
   launch_template {
     id      = aws_launch_template.obi_one_v2_ec2_launch_template.id
-    version = "$Latest"
+    version = aws_launch_template.obi_one_v2_ec2_launch_template.latest_version
   }
 
   instance_refresh { strategy = "Rolling" }


### PR DESCRIPTION
Based on the note in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#instance_refresh

> A refresh will not start when version = "$Latest" is configured in the launch_template block. To trigger the instance refresh when a launch template is changed, configure version to use the latest_version attribute of the aws_launch_template resource.

