### PR TITLE
Attach AWS-managed AWSBackupServiceRolePolicyForS3Backup to backup-role

### DIFF
--- a/backups/backup_plan.tf
+++ b/backups/backup_plan.tf
@@ -102,6 +102,10 @@ resource "aws_iam_role_policy" "backup_role_policy" {
   })
 }
 
+resource "aws_iam_role_policy_attachment" "backup_role_managed_s3_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
+  role       = aws_iam_role.backup_role.name
+}
 
 resource "aws_backup_selection" "obi_plan_selection" {
   name         = "obi_plan_selection"
@@ -114,3 +118,4 @@ resource "aws_backup_selection" "obi_plan_selection" {
     value = "obi_plan"
   }
 }
+


### PR DESCRIPTION
Making sure that missing permissions aren't to blame for the backup failure of the entitycore S3 bucket.