### PR TITLE
obi_one_v2: allow EC2 to scale up for new deployments

### DIFF
--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -445,13 +445,13 @@ resource "aws_ecs_capacity_provider" "obi_one_v2_cas" {
   name = "obi_one_v2_ecs_capacity_provider"
 
   auto_scaling_group_provider {
-    auto_scaling_group_arn = aws_autoscaling_group.obi_one_v2_ecs_autoscaling_group.arn
-
+    auto_scaling_group_arn         = aws_autoscaling_group.obi_one_v2_ecs_autoscaling_group.arn
+    managed_termination_protection = "ENABLED"
     managed_scaling {
-      #maximum_scaling_step_size = 1
-      #minimum_scaling_step_size = 1
-      status = "ENABLED"
-      #target_capacity           = 1
+      status                    = "ENABLED"
+      target_capacity           = 100
+      minimum_scaling_step_size = 1
+      maximum_scaling_step_size = 1
     }
   }
 
@@ -513,8 +513,9 @@ resource "aws_appautoscaling_policy" "obi_one_v2_ecs_memory_policy" {
 ## Creates an ASG linked with our main VPC
 resource "aws_autoscaling_group" "obi_one_v2_ecs_autoscaling_group" {
   name_prefix           = "obi-one-v2-ecs-asg"
-  max_size              = 1
+  max_size              = 2
   min_size              = 1
+  desired_capacity      = 1
   vpc_zone_identifier   = [aws_subnet.obi_one_v2.id]
   health_check_type     = "EC2"
   protect_from_scale_in = true

--- a/production.tfvars
+++ b/production.tfvars
@@ -93,8 +93,8 @@ entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/en
 obi_one_v2_docker_image_url  = "public.ecr.aws/openbraininstitute/obi-one:2025.10.3"
 obi_one_v2_ec2_instance_type = "t3.large" # vCPUs: 2, Memory: 8 GiB
 obi_one_v2_ecs_task_size = {
-  cpu    = 1024
-  memory = 7168 # need to leave some free memory for new deployments
+  cpu    = 2048
+  memory = 7680
   tmpfs  = 512
 }
 

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -114,8 +114,8 @@ entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/en
 obi_one_v2_docker_image_url  = "public.ecr.aws/openbraininstitute/obi-one:2025.10.4"
 obi_one_v2_ec2_instance_type = "t3.small" # vCPUs: 2, Memory: 2 GiB
 obi_one_v2_ecs_task_size = {
-  cpu    = 1024
-  memory = 1536 # need to leave some free memory for new deployments
+  cpu    = 2048
+  memory = 1536
   tmpfs  = 512
 }
 


### PR DESCRIPTION
We deploy only 1 ECS task in EC2 and we want to use most the available memory for this single task.
However, this would prevent rolling deployments, because there are no resources to deploy a new task in the same EC2.
With this change, a new EC2 instance should be deployed, with a new ECS task, before stopping the old one.

Downsides:
- higher deployment time (to start a new EC2 instance, mount S3)
- S3 cache won't persist after deployments