### PR TITLE
obi_one_v2: fix autoscaling v2

### DIFF
--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -282,13 +282,17 @@ resource "aws_ecs_task_definition" "obi_one_v2_ecs_definition" {
 resource "aws_ecs_service" "obi_one_v2_ecs_service" {
   name            = "obi_one_v2_service"
   cluster         = aws_ecs_cluster.obi_one_v2_ecs_cluster.id
-  launch_type     = "EC2"
   task_definition = aws_ecs_task_definition.obi_one_v2_ecs_definition.arn
   desired_count   = var.obi_one_v2_ecs_number_of_containers
 
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 180
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.obi_one_v2_cas.name
+    weight            = 1
+  }
 
   ## Make use of all available space on the Container Instances
   ordered_placement_strategy {
@@ -548,6 +552,12 @@ resource "aws_autoscaling_group" "obi_one_v2_ecs_autoscaling_group" {
   tag {
     key                 = "SBO_Billing"
     value               = "obi_one_v2"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = ""
     propagate_at_launch = true
   }
 }


### PR DESCRIPTION
From https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider:

> Associating an ECS Capacity Provider to an Auto Scaling Group will automatically add the AmazonECSManaged tag to the Auto Scaling Group. This tag should be included in the aws_autoscaling_group resource configuration to prevent Terraform from removing it in subsequent executions as well as ensuring the AmazonECSManaged tag is propagated to all EC2 Instances in the Auto Scaling Group if min_size is above 0 on creation. Any EC2 Instances in the Auto Scaling Group without this tag must be manually be updated, otherwise they may cause unexpected scaling behavior and metrics.

