### PR TITLE
obi_one: set protect_from_scale_in = false

### DIFF
--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -522,7 +522,7 @@ resource "aws_autoscaling_group" "obi_one_v2_ecs_autoscaling_group" {
   desired_capacity      = 1
   vpc_zone_identifier   = [aws_subnet.obi_one_v2.id]
   health_check_type     = "EC2"
-  protect_from_scale_in = true
+  protect_from_scale_in = false
 
   enabled_metrics = [
     "GroupMinSize",


### PR DESCRIPTION
Set `protect_from_scale_in = false` to allow faster scale down of the EC2 instances after a new deployment.

It has been observed that after a new deployment of the service, that requires spinning up a new EC2 instance, the desired capacity of the autoscaling group stays at 2, although it decreases to 1 after some time, and the old EC2 instance is then destroyed.

This is an attempt to make the scaling down faster.

cc @danifr 