### PR TITLE
Update entitycore image version to 2025.10.8

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -109,7 +109,7 @@ entitycore_svc_aws_s3_internal_region    = "us-east-1"
 entitycore_svc_aws_s3_open_bucket        = "openbluebrain"
 entitycore_svc_aws_s3_open_region        = "us-west-2"
 entitycore_svc_s3_bucket_allowed_origins = ["*"]
-entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.10.7"
+entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2025.10.8"
 
 obi_one_v2_docker_image_url  = "public.ecr.aws/openbraininstitute/obi-one:2025.10.5"
 obi_one_v2_ec2_instance_type = "t3.small" # vCPUs: 2, Memory: 2 GiB


### PR DESCRIPTION
This is a hotfix that needs to be deployed to staging.

Image built in: https://github.com/openbraininstitute/entitycore/actions/runs/18844973980/job/53766506431