### PR TITLE
obi-one-v2: Enable protection from scale-in for the auto-scaling group

### DIFF
--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -522,7 +522,7 @@ resource "aws_autoscaling_group" "obi_one_v2_ecs_autoscaling_group" {
   desired_capacity      = 1
   vpc_zone_identifier   = [aws_subnet.obi_one_v2.id]
   health_check_type     = "EC2"
-  protect_from_scale_in = false
+  protect_from_scale_in = true
 
   enabled_metrics = [
     "GroupMinSize",


### PR DESCRIPTION
Without it, it causes:

│ Error: creating ECS Capacity Provider (obi_one_v2_ecs_capacity_provider): operation error ECS: CreateCapacityProvider, https response error StatusCode: 400, RequestID: b28bf864-4cce-49fe-8616-c49d62efb9d2, ClientException: The managed termination protection setting for the capacity provider is invalid. To enable managed termination protection for a capacity provider, the Auto Scaling group must have instance protection from scale in enabled.
