### PR TITLE
Enable Amazon GuardDuty detector in staging

### DIFF
--- a/cs/guardduty/detector.tf
+++ b/cs/guardduty/detector.tf
@@ -1,0 +1,36 @@
+resource "aws_guardduty_detector" "obi" {
+  enable = var.is_enabled
+  tags = {
+    SBO_Billing = "guardduty"
+  }
+}
+
+resource "aws_guardduty_detector_feature" "s3_protection" {
+  detector_id = aws_guardduty_detector.obi.id
+  name        = "S3_DATA_EVENTS"
+  status      = "ENABLED"
+}
+
+resource "aws_guardduty_detector_feature" "ebs_protection" {
+  detector_id = aws_guardduty_detector.obi.id
+  name        = "EBS_MALWARE_PROTECTION"
+  status      = "ENABLED"
+}
+
+resource "aws_guardduty_detector_feature" "rds_protection" {
+  detector_id = aws_guardduty_detector.obi.id
+  name        = "RDS_LOGIN_EVENTS"
+  status      = "ENABLED"
+}
+
+resource "aws_guardduty_detector_feature" "lambda_protection" {
+  detector_id = aws_guardduty_detector.obi.id
+  name        = "LAMBDA_NETWORK_LOGS"
+  status      = "ENABLED"
+}
+
+resource "aws_guardduty_detector_feature" "runtime_protection" {
+  detector_id = aws_guardduty_detector.obi.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+}

--- a/cs/guardduty/variables.tf
+++ b/cs/guardduty/variables.tf
@@ -1,0 +1,5 @@
+variable "is_enabled" {
+  description = "Whether guardduty is enabled or not"
+  type        = bool
+  default     = false
+}

--- a/cs/main.tf
+++ b/cs/main.tf
@@ -83,3 +83,8 @@ module "secret_sharing_svc" {
     memory = 512
   }
 }
+
+module "guardduty" {
+  source     = "./guardduty"
+  is_enabled = var.is_staging ? true : false # only enabled in staging for now
+}


### PR DESCRIPTION
For https://github.com/openbraininstitute/INFRA/issues/308

EKS protection will require a little bit more work so it is not part of this change yet.