### PR TITLE
Remove family from container_definitions

### DIFF
--- a/accounting_svc/backend.tf
+++ b/accounting_svc/backend.tf
@@ -86,8 +86,7 @@ resource "aws_ecs_task_definition" "accounting_ecs_definition" {
 
   container_definitions = jsonencode([
     {
-      name   = "accounting"
-      family = "accounting"
+      name = "accounting"
 
       cpu    = local.cpu
       memory = local.memory

--- a/auth-manager/service.tf
+++ b/auth-manager/service.tf
@@ -86,8 +86,7 @@ resource "aws_ecs_task_definition" "auth_manager_ecs_definition" {
 
   container_definitions = jsonencode([
     {
-      name   = "auth_manager"
-      family = "auth_manager"
+      name = "auth_manager"
 
       cpu    = local.cpu
       memory = local.memory

--- a/cells_svc/cell-svc-container.tf
+++ b/cells_svc/cell-svc-container.tf
@@ -211,7 +211,6 @@ resource "aws_ecs_task_definition" "cell_svc_ecs_definition" {
       memory      = 1536
       cpu         = 256
       networkMode = "awsvpc"
-      family      = "sbocellsvc"
       essential   = true
       image       = var.cell_svc_docker_image_url
       name        = "cell_svc"

--- a/core_webapp/container.tf
+++ b/core_webapp/container.tf
@@ -96,7 +96,6 @@ resource "aws_ecs_task_definition" "core_webapp_ecs_definition" {
       cpu         = local.cpu
       memory      = local.memory
       networkMode = "awsvpc"
-      family      = "corewebapp"
       essential   = true
       image       = var.docker_image_url
       name        = "core_webapp"

--- a/entitycore_svc/backend.tf
+++ b/entitycore_svc/backend.tf
@@ -86,8 +86,7 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
 
   container_definitions = jsonencode([
     {
-      name   = "entitycore"
-      family = "entitycore"
+      name = "entitycore"
 
       cpu    = local.cpu
       memory = local.memory

--- a/ml/agent.tf
+++ b/ml/agent.tf
@@ -52,7 +52,6 @@ module "ecs_service_agent" {
       memory                   = 2048
       cpu                      = 1024
       networkMode              = "awsvpc"
-      family                   = "ml_agent"
       essential                = true
       image                    = var.neuroagent_docker_image_url
       name                     = "ml_agent"

--- a/notebook_service/backend.tf
+++ b/notebook_service/backend.tf
@@ -124,8 +124,7 @@ resource "aws_ecs_task_definition" "ecs_definition" {
 
   container_definitions = jsonencode([
     {
-      name   = "notebook_service"
-      family = "notebook_service"
+      name = "notebook_service"
 
       cpu    = var.task_size.cpu
       memory = var.task_size.memory

--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -193,7 +193,6 @@ resource "aws_ecs_task_definition" "obi_one_v2_ecs_definition" {
       memory      = var.ecs_task_size.memory
       cpu         = var.ecs_task_size.cpu
       networkMode = "awsvpc"
-      family      = "obi_one_v2"
       essential   = true
       image       = var.docker_image_url
       name        = "obi_one_v2"

--- a/on_demand_svc/ecs.tf
+++ b/on_demand_svc/ecs.tf
@@ -150,7 +150,6 @@ resource "aws_ecs_task_definition" "this" {
       memory      = var.ecs_memory
       cpu         = var.ecs_cpu
       networkMode = "awsvpc"
-      family      = local.cluster_name
       essential   = true
       image       = var.svc_image
       linuxParameters = var.ecs_task_type == "EC2" ? {

--- a/virtual-lab-manager/container.tf
+++ b/virtual-lab-manager/container.tf
@@ -89,7 +89,6 @@ resource "aws_ecs_task_definition" "virtual_lab_manager_ecs_definition" {
       cpu         = var.task_size.cpu
       memory      = var.task_size.memory
       networkMode = "awsvpc"
-      family      = "virtuallabmanager"
       essential   = true
       image       = var.virtual_lab_manager_docker_image_url
       name        = "virtual_lab_manager"


### PR DESCRIPTION
Remove family from container_definitions because it doesn't look like it's a valid parameter in the container_definitions, while it's needed in the aws_ecs_task_definition