### PR TITLE
Core web app: extend runtime config

### DIFF
--- a/core_webapp/container.tf
+++ b/core_webapp/container.tf
@@ -116,23 +116,43 @@ resource "aws_ecs_task_definition" "core_webapp_ecs_definition" {
       }
       environment = [
         {
-          name  = "ACCOUNTING_BASE_URL"
-          value = var.accounting_base_url
+          name  = "DEPLOYMENT_ENV"
+          value = var.deployment_env
         },
         {
-          name  = "NEXTAUTH_URL"
-          value = var.env_NEXTAUTH_URL
+          name  = "API_ORIGIN"
+          value = var.api_origin
         },
         {
           name  = "KEYCLOAK_ISSUER"
-          value = var.env_KEYCLOAK_ISSUER
+          value = var.keycloak_issuer
         },
         {
           name  = "KEYCLOAK_CLIENT_ID"
           value = "core-webapp-${var.key}"
         },
         {
-          name  = "NEXT_PUBLIC_CDN_URI"
+          name  = "MATOMO_SITE_ID"
+          value = var.matomo_site_id
+        },
+        {
+          name  = "NEXTAUTH_URL"
+          value = var.auth_url
+        },
+        {
+          name  = "PRIMARY_HOSTNAME"
+          value = var.primary_hostname
+        },
+        {
+          name  = "SANITY_DATASET"
+          value = var.sanity_dataset
+        },
+        {
+          name  = "STRIPE_PUBLISHABLE_KEY"
+          value = var.stripe_publishable_key
+        },
+        {
+          name  = "CDN_URL"
           value = var.key == "main" ? "https://${aws_cloudfront_distribution.core_webapp_cdn[0].domain_name}" : "https://placeholder"
         },
       ]

--- a/core_webapp/variables.tf
+++ b/core_webapp/variables.tf
@@ -81,21 +81,61 @@ variable "secrets_arn" {
   sensitive   = false
 }
 
-variable "accounting_base_url" {
+variable "auth_url" {
   type        = string
-  description = "Accounting service base URL"
   sensitive   = false
+  description = "NextAuth endpoint URL"
 }
 
-variable "env_NEXTAUTH_URL" {
+variable "deployment_env" {
   type        = string
   sensitive   = false
-  description = "NEXTAUTH_URL environment value for the webapp"
+  description = "Name of the deployment environment"
+  validation {
+    condition     = contains(["preview", "development", "staging", "production"], var.deployment_env)
+    error_message = "Invalid deployment environment name"
+  }
 }
-variable "env_KEYCLOAK_ISSUER" {
+
+variable "sanity_dataset" {
   type        = string
   sensitive   = false
-  description = "KEYCLOAK_ISSUER environment value for the webapp"
+  description = "Sanity dataset name"
+  validation {
+    condition     = contains(["staging", "production"], var.sanity_dataset)
+    error_message = "Invalid Sanity dataset name"
+  }
+}
+
+variable "stripe_publishable_key" {
+  type        = string
+  sensitive   = false
+  description = "Stripe publishable key"
+}
+
+variable "matomo_site_id" {
+  type        = string
+  sensitive   = false
+  description = "Matomo site ID"
+}
+
+# TODO: Check if we still need domain redirects, clean up if not.
+variable "primary_hostname" {
+  type        = string
+  sensitive   = false
+  description = "Used for domain redirect, e.g. https://openbluebrain.com -> https://www.openbraininstitute.org/"
+}
+
+variable "api_origin" {
+  type        = string
+  sensitive   = false
+  description = "Default origin for all API services"
+}
+
+variable "keycloak_issuer" {
+  type        = string
+  sensitive   = false
+  description = "Keycloak issuer URL"
 }
 
 # S3 and CloudFront Configuration Variables

--- a/main.tf
+++ b/main.tf
@@ -463,7 +463,6 @@ module "core_webapp_main" {
   route_table_id                = local.route_table_private_subnets_id
   vpc_cidr_block                = local.vpc_cidr_block
   secrets_arn                   = local.core_webapp_secrets_arn
-  accounting_base_url           = "https://${local.primary_domain}${var.accounting_svc_base_path}"
   s3_bucket_name                = var.core_webapp_s3_bucket_name
   s3_bucket_allowed_origins     = ["https://${local.primary_domain}", "https://${join(".", ["cdn", trimprefix(local.primary_domain, "www.")])}"]
 
@@ -472,8 +471,14 @@ module "core_webapp_main" {
   domain_name                = local.primary_domain
   cloudfront_certificate_arn = local.cloudfront_certificate_arn
 
-  env_NEXTAUTH_URL    = "https://${local.primary_domain}/api/auth"
-  env_KEYCLOAK_ISSUER = "https://${local.primary_domain}/auth/realms/SBO"
+  api_origin             = "https://${local.primary_domain}"
+  auth_url               = "https://${local.primary_domain}/api/auth"
+  deployment_env         = var.is_staging ? "staging" : "production"
+  keycloak_issuer        = "https://${local.primary_domain}/auth/realms/SBO"
+  matomo_site_id         = var.is_production ? "1" : "3"
+  primary_hostname       = local.primary_domain
+  sanity_dataset         = var.is_production ? "production" : "staging"
+  stripe_publishable_key = var.core_web_app_stripe_publishable_key
 }
 
 module "core_webapp_dev" {
@@ -496,7 +501,6 @@ module "core_webapp_dev" {
   route_table_id                = local.route_table_private_subnets_id
   vpc_cidr_block                = local.vpc_cidr_block
   secrets_arn                   = local.core_webapp_secrets_arn
-  accounting_base_url           = "https://${local.primary_domain}${var.accounting_svc_base_path}"
 
   // These are not used in dev
   s3_bucket_name            = var.core_webapp_s3_bucket_name
@@ -504,8 +508,14 @@ module "core_webapp_dev" {
 
   sbo_billing_tag = "core_webapp_dev"
 
-  env_NEXTAUTH_URL    = "https://dev.openbraininstitute.org/api/auth"
-  env_KEYCLOAK_ISSUER = "https://${local.primary_domain}/auth/realms/SBO"
+  api_origin             = "https://${local.primary_domain}"
+  auth_url               = "https://dev.openbraininstitute.org/api/auth"
+  deployment_env         = "development"
+  keycloak_issuer        = "https://${local.primary_domain}/auth/realms/SBO"
+  matomo_site_id         = "3"
+  primary_hostname       = "dev.openbraininstitute.org"
+  sanity_dataset         = "staging"
+  stripe_publishable_key = var.core_web_app_stripe_publishable_key
 }
 
 module "core_webapp_preview" {
@@ -528,7 +538,6 @@ module "core_webapp_preview" {
   route_table_id                = local.route_table_private_subnets_id
   vpc_cidr_block                = local.vpc_cidr_block
   secrets_arn                   = local.core_webapp_secrets_arn
-  accounting_base_url           = "https://${local.primary_domain}${var.accounting_svc_base_path}"
 
   // These are not used in preview
   s3_bucket_name            = var.core_webapp_s3_bucket_name
@@ -536,8 +545,14 @@ module "core_webapp_preview" {
 
   sbo_billing_tag = "core_webapp_preview"
 
-  env_NEXTAUTH_URL    = "https://preview.openbraininstitute.org/api/auth"
-  env_KEYCLOAK_ISSUER = "https://${local.primary_domain}/auth/realms/SBO"
+  api_origin             = "https://${local.primary_domain}"
+  auth_url               = "https://preview.openbraininstitute.org/api/auth"
+  deployment_env         = "preview"
+  keycloak_issuer        = "https://${local.primary_domain}/auth/realms/SBO"
+  matomo_site_id         = "3"
+  primary_hostname       = "preview.openbraininstitute.org"
+  sanity_dataset         = "staging"
+  stripe_publishable_key = var.core_web_app_stripe_publishable_key
 }
 
 module "github_core_webapp_dev_ecs_redeploy_role" {

--- a/production.tfvars
+++ b/production.tfvars
@@ -82,6 +82,8 @@ small_scale_simulator_batch_workers = {
   }
 }
 
+core_web_app_stripe_publishable_key = "pk_live_51QjjHBKGUR5u3ofL3U1YQwXofi5vIEpo6mOfWOVqBiV6aWy0Gz7y6h1lMos5uzTseL2UExqBMuYq5uwUUWZss5SH00dP35riR3"
+
 virtual_lab_manager_task_size = {
   cpu    = 1024
   memory = 2048

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -84,6 +84,8 @@ small_scale_simulator_batch_workers = {
   }
 }
 
+core_web_app_stripe_publishable_key = "pk_test_51QjjHBKGUR5u3ofLgNUOpljnvy27UTTpkhwgsLiwK9xlNjnR7CZfiMjtZWMjgN7GW3eDyzMJ7Z1pIqC9LiwkfQRX00ebb5c9XI"
+
 virtual_lab_manager_task_size = {
   cpu    = 512
   memory = 1024

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -59,6 +59,11 @@ variable "core_web_app_preview_docker_image_url" {
   sensitive   = false
 }
 
+variable "core_web_app_stripe_publishable_key" {
+  type        = string
+  description = "Stripe publishable key for the core-web-app"
+}
+
 variable "neuroagent_docker_image_url" {
   default     = null
   type        = string


### PR DESCRIPTION
This comes along with the change to the core web app (PR: [Runtime configuration system](https://github.com/openbraininstitute/core-web-app/pull/1108)) to enable providing the configuration exclusively during the runtime which makes it possible to re-use an image across different deployments (dev, staging, production).