### PR TITLE
Block all public access for static_storage S3 bucket

### DIFF
--- a/static-server/main.tf
+++ b/static-server/main.tf
@@ -96,13 +96,13 @@ resource "aws_s3_bucket_metric" "static_storage_metrics" {
   name   = "EntireBucket"
 }
 
-#tfsec:ignore:aws-s3-no-public-buckets
-#tfsec:ignore:aws-s3-block-public-policy
 resource "aws_s3_bucket_public_access_block" "static_storage" {
   bucket = aws_s3_bucket.static_storage.id
 
-  block_public_acls  = true
-  ignore_public_acls = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_policy" "static_storage" {


### PR DESCRIPTION
Fix for one of the critical findings SecurityHub raised: "S3 general purpose buckets should block public read access"

https://github.com/openbraininstitute/INFRA/issues/361

