### PR TITLE
Auth manager: temporarily redirect clients to dev domain

### DIFF
--- a/auth-manager/service.tf
+++ b/auth-manager/service.tf
@@ -156,7 +156,7 @@ resource "aws_ecs_task_definition" "auth_manager_ecs_definition" {
         },
         {
           name  = "KEYCLOAK_AFTER_CONSENT_REDIRECT_URI"
-          value = "https://${var.primary_domain}/app/consent-feedback"
+          value = "https://${var.client_redirect_domain}/app/consent-feedback"
         },
         {
           name  = "ACK_STATE_EXPIRY"

--- a/auth-manager/variables.tf
+++ b/auth-manager/variables.tf
@@ -67,6 +67,11 @@ variable "primary_domain" {
   type = string
 }
 
+variable "client_redirect_domain" {
+  type        = string
+  description = "Domain where users are redirected after granting offline token consent"
+}
+
 variable "keycloak_client_uuid" {
   type = string
 }

--- a/main.tf
+++ b/main.tf
@@ -654,6 +654,9 @@ module "auth_manager" {
 
   primary_domain = local.primary_domain
 
+  # TODO Revert this back to staging. once the core web app with auth-manager support is deployed.
+  client_redirect_domain = "dev.openbraininstitute.org"
+
   image_url = var.auth_manager_svc_image_url
 
   keycloak_client_uuid = var.keycloak_client_uuid


### PR DESCRIPTION
This is a temporary solution to make auth manager work with core web app in dev, until we deploy new core web app (with auth-manager enabled) to staging.