### PR TITLE
Remove allowed_source_ip_cidr_blocks variable in auth-manager

### DIFF
--- a/auth-manager/alb.tf
+++ b/auth-manager/alb.tf
@@ -34,10 +34,5 @@ resource "aws_lb_listener_rule" "auth_manager_private_listener_rule" {
     }
   }
 
-  condition {
-    source_ip {
-      values = var.allowed_source_ip_cidr_blocks
-    }
-  }
   tags = var.auth_manager_svc_tags
 }

--- a/auth-manager/security-groups.tf
+++ b/auth-manager/security-groups.tf
@@ -8,14 +8,14 @@ resource "aws_security_group" "auth_manager_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "postgres_from_vpc" {
-  for_each          = toset(var.allowed_source_ip_cidr_blocks)
   security_group_id = aws_security_group.auth_manager_sg.id
   description       = "Allow Postgres access from the VPC"
   from_port         = 5432
   to_port           = 5432
   ip_protocol       = "tcp"
-  cidr_ipv4         = each.key
+  cidr_ipv4         = data.aws_vpc.main.cidr_block
 }
+
 resource "aws_vpc_security_group_ingress_rule" "main_subnet_ingress" {
   security_group_id = aws_security_group.auth_manager_sg.id
   description       = "Allow everything incoming from the VPC"

--- a/auth-manager/variables.tf
+++ b/auth-manager/variables.tf
@@ -20,7 +20,6 @@ variable "db_username" {
   type        = string
 }
 
-
 variable "obi_backup_plan" {
   description = "Name of the OBI backup plan"
   type        = string
@@ -43,10 +42,6 @@ variable "root_path" {
 variable "cors_origins" {
   description = "CORS origins"
   type        = list(string)
-}
-
-variable "allowed_source_ip_cidr_blocks" {
-  type = list(string)
 }
 
 variable "private_alb_listener_arn" {

--- a/main.tf
+++ b/main.tf
@@ -706,12 +706,11 @@ module "auth_manager" {
 
   number_of_containers = var.is_staging ? 1 : 0
 
-  aws_region                    = local.aws_region
-  vpc_id                        = local.vpc_id
-  private_alb_listener_arn      = local.private_alb_https_listener_arn
-  internet_access_route_id      = local.route_table_private_subnets_id
-  allowed_source_ip_cidr_blocks = ["0.0.0.0/0"]
-  route_table_id                = local.route_table_private_subnets_id
+  aws_region               = local.aws_region
+  vpc_id                   = local.vpc_id
+  private_alb_listener_arn = local.private_alb_https_listener_arn
+  internet_access_route_id = local.route_table_private_subnets_id
+  route_table_id           = local.route_table_private_subnets_id
 
   cors_origins = local.core_web_app_origins
 


### PR DESCRIPTION
The rational of this change is: https://github.com/openbraininstitute/INFRA/issues/381

@bilalesi when you have some time, can you please review it? No rush.