### PR TITLE
Delete accounting SG ingress rule

### DIFF
--- a/accounting_svc/backend.tf
+++ b/accounting_svc/backend.tf
@@ -50,16 +50,6 @@ resource "aws_vpc_security_group_ingress_rule" "accounting_allow_port_8000" {
   description = "Allow port 8000 http"
 }
 
-resource "aws_vpc_security_group_ingress_rule" "accounting_allow_in_tcp" {
-  security_group_id = aws_security_group.accounting_ecs_task.id
-  # TODO limit to what is needed
-  ip_protocol = "tcp"
-  from_port   = 0
-  to_port     = 65535
-  cidr_ipv4   = "0.0.0.0/0"
-  description = "Allow all TCP"
-}
-
 resource "aws_vpc_security_group_egress_rule" "accounting_allow_outgoing_tcp" {
   security_group_id = aws_security_group.accounting_ecs_task.id
   # TODO limit to what is needed


### PR DESCRIPTION
Hi @GianlucaFicarelli this change is part of https://github.com/openbraininstitute/INFRA/issues/381 

AFAIK we can delete this rule since we already have:
 https://github.com/openbraininstitute/aws-terraform-deployment/blob/staging/accounting_svc/backend.tf#L43 (only allowing port 8000 from the VPC)

Please let me know.