### PR TITLE
Set KC_HTTP_ACCEPT_NON_NORMALIZED_PATHS to true

### DIFF
--- a/cs/keycloak/task.tf
+++ b/cs/keycloak/task.tf
@@ -110,6 +110,10 @@ resource "aws_ecs_task_definition" "sbo_keycloak_task" {
           name  = "JAVA_OPTS_APPEND"
           value = "-XX:MaxRAMPercentage=75.0"
         },
+        {
+          name  = "KC_HTTP_ACCEPT_NON_NORMALIZED_PATHS"
+          value = "true"
+        },
       ]
       secrets = [
         {


### PR DESCRIPTION
After the keycloak upgrade to 26.4.7 we got some errors related to paths. This is a workaround until we figure out a proper fix