### PR TITLE
Enable readonlyRootFilesystem for thumbnail-generation service

### DIFF
--- a/thumbnail-generation-api/thumbnail-generation-api-container.tf
+++ b/thumbnail-generation-api/thumbnail-generation-api-container.tf
@@ -153,6 +153,10 @@ resource "aws_ecs_task_definition" "thumbnail_generation_api_task_definition" {
   }
 
   volume {
+    name = "var-run"
+  }
+
+  volume {
     name = "app-output"
   }
 
@@ -172,6 +176,10 @@ resource "aws_ecs_task_definition" "thumbnail_generation_api_task_definition" {
           {
             sourceVolume  = "var-cache-nginx",
             containerPath = "/var/cache/nginx"
+          },
+          {
+            sourceVolume  = "var-run",
+            containerPath = "/var/run"
           },
           {
             sourceVolume  = "app-output",
@@ -204,6 +212,10 @@ resource "aws_ecs_task_definition" "thumbnail_generation_api_task_definition" {
           {
             name : "ENTITY_CORE_URI",
             value : var.entitycore_url
+          },
+          {
+            name  = "MPLCONFIGDIR",
+            value = "/tmp/matplotlib"
           }
         ],
         memory = 2048

--- a/thumbnail-generation-api/thumbnail-generation-api-container.tf
+++ b/thumbnail-generation-api/thumbnail-generation-api-container.tf
@@ -144,14 +144,40 @@ resource "aws_ecs_task_definition" "thumbnail_generation_api_task_definition" {
   memory                   = 4096
   cpu                      = 2048
 
+  volume {
+    name = "tmp"
+  }
+
+  volume {
+    name = "var-cache-nginx"
+  }
+
+  volume {
+    name = "app-output"
+  }
 
   # Container definition for FastAPI
   container_definitions = jsonencode(
     [
       {
-        name      = "thumbnail-generation-api-container",
-        image     = var.thumbnail_generation_api_docker_image_url,
-        essential = true,
+        name                   = "thumbnail-generation-api-container",
+        image                  = var.thumbnail_generation_api_docker_image_url,
+        essential              = true,
+        readonlyRootFilesystem = true,
+        mountPoints = [
+          {
+            sourceVolume  = "tmp",
+            containerPath = "/tmp"
+          },
+          {
+            sourceVolume  = "var-cache-nginx",
+            containerPath = "/var/cache/nginx"
+          },
+          {
+            sourceVolume  = "app-output",
+            containerPath = "/app/output"
+          }
+        ],
         portMappings = [
           {
             containerPort = 80,


### PR DESCRIPTION
I checked the code and it seems it needs write access to `/tmp`, `/var/cache/nginx`, and `/app/output`

For https://github.com/openbraininstitute/INFRA/issues/391

