### PR TITLE
Replace FONTCONFIG_PATH by FONTCONFIG_CACHE_DIR

### DIFF
--- a/thumbnail-generation-api/thumbnail-generation-api-container.tf
+++ b/thumbnail-generation-api/thumbnail-generation-api-container.tf
@@ -226,7 +226,7 @@ resource "aws_ecs_task_definition" "thumbnail_generation_api_task_definition" {
             value = "/tmp/matplotlib"
           },
           {
-            name  = "FONTCONFIG_PATH",
+            name  = "FONTCONFIG_CACHE_DIR",
             value = "/tmp/fontconfig"
           }
         ],


### PR DESCRIPTION
Specifies where to write cache files and must be writable.