### PR TITLE
Update network ACL rules of the JupyterHub subnets so the nodes can access the public launch data EFS, part 3

### DIFF
--- a/cs/jupyterhub_eks/subnets.tf
+++ b/cs/jupyterhub_eks/subnets.tf
@@ -68,6 +68,29 @@ resource "aws_network_acl" "jupyterhub_eks_public" {
   }
 }
 
+# for public launch data EFS
+resource "aws_network_acl_rule" "jupyterhub_eks_public_launch_data_efs_ingress1" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_public.id
+  rule_number    = 40
+  protocol       = "tcp"
+  from_port      = 1024
+  to_port        = 65535
+  rule_action    = "allow"
+  cidr_block     = var.public_data_efs_ip_address1_as_cidr
+  egress         = false
+}
+
+resource "aws_network_acl_rule" "jupyterhub_eks_public_launch_data_efs_ingress2" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_public.id
+  rule_number    = 41
+  protocol       = "tcp"
+  from_port      = 1024
+  to_port        = 65535
+  rule_action    = "allow"
+  cidr_block     = var.public_data_efs_ip_address2_as_cidr
+  egress         = false
+}
+
 resource "aws_network_acl_rule" "jupyterhub_eks_public_endpoints_ingress" {
   network_acl_id = aws_network_acl.jupyterhub_eks_public.id
   rule_number    = 50
@@ -173,6 +196,28 @@ resource "aws_network_acl_rule" "jupyterhub_eks_public_ingress" {
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   egress         = false
+}
+
+resource "aws_network_acl_rule" "jupyterhub_eks_public_access_to_public_launch_nfs1" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_public.id
+  rule_number    = 40
+  protocol       = "tcp"
+  from_port      = 2049
+  to_port        = 2049
+  rule_action    = "allow"
+  cidr_block     = var.public_data_efs_ip_address1_as_cidr
+  egress         = true
+}
+
+resource "aws_network_acl_rule" "jupyterhub_eks_public_access_to_public_launch_nfs2" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_public.id
+  rule_number    = 41
+  protocol       = "tcp"
+  from_port      = 2049
+  to_port        = 2049
+  rule_action    = "allow"
+  cidr_block     = var.public_data_efs_ip_address2_as_cidr
+  egress         = true
 }
 
 resource "aws_network_acl_rule" "jupyterhub_eks_public_endpoints_egress" {


### PR DESCRIPTION
https://github.com/openbraininstitute/INFRA/issues/392
