### PR TITLE
Enable readonlyRootFilesystem for neuroagent service

### DIFF
--- a/ml/agent.tf
+++ b/ml/agent.tf
@@ -52,7 +52,13 @@ module "ecs_service_agent" {
       essential                = true
       image                    = var.neuroagent_docker_image_url
       name                     = "ml_agent"
-      readonly_root_filesystem = false
+      readonly_root_filesystem = true
+      mount_points = [
+        {
+          sourceVolume  = "tmp"
+          containerPath = "/tmp"
+        }
+      ]
       port_mappings = [
         {
           name          = "ml_agent"
@@ -137,8 +143,6 @@ module "ecs_service_agent" {
         {
           name  = "NEUROAGENT_TOOLS__WHITELISTED_TOOL_REGEX"
           value = "^(?!.*(downloadone|measurementannotation|simulation|synaptome|experimentalsynapsesperconnection|expert)).*"
-
-
         },
       ]
       secrets = [
@@ -159,8 +163,11 @@ module "ecs_service_agent" {
           valueFrom = "${var.ml_secrets_arn}:EXA_API_KEY::"
         },
       ]
-      readonly_root_filesystem = false
     }
+  }
+
+  volume = {
+    tmp = {}
   }
 
   task_exec_iam_role_policies = {


### PR DESCRIPTION
Depends on https://github.com/openbraininstitute/neuroagent/pull/683

Before merging this one a new version of neuroagent needs to be released and deployed in staging.