### PR TITLE
Remove curl sudo and jq as they come preinstalled in AL2023

### DIFF
--- a/bastion_host/scripts/user_setup.sh
+++ b/bastion_host/scripts/user_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Install required packages
 dnf update -y
-dnf install -y curl git jq lsof nmap nmap-ncat postgresql17 rsync strace sudo tcpdump tmux traceroute vim wget zsh
+dnf install -y git lsof nmap nmap-ncat postgresql17 rsync strace tcpdump tmux traceroute vim wget zsh
 
 # Install SSM Agent for Amazon Linux 2023
 dnf install -y amazon-ssm-agent


### PR DESCRIPTION
https://docs.aws.amazon.com/linux/al2023/ug/curl-minimal.html


> AL2023 separates out the common protocols and functionality of the curl and libcurl packages into curl-minimal and libcurl-minimal. This reduces the disk, memory, and dependency footprint for most users, and is the default package for AL2023 AMIs and containers.

> If the full functionality of curl is required, for example for gopher:// support, run the following commands to install the curl-full and libcurl-full packages.

> $ dnf swap libcurl-minimal libcurl-full
$ dnf swap curl-minimal curl-full