### PR TITLE
Fix StopTask ecs policy for launch_system orchestrator

### DIFF
--- a/launch_system/orchestrator.tf
+++ b/launch_system/orchestrator.tf
@@ -273,7 +273,6 @@ resource "aws_iam_policy" "orchestrator_ecs_run_task" {
         Effect = "Allow"
         Action = [
           "ecs:DescribeTasks",
-          "ecs:StopTask",
           "ecs:ListTasks",
         ]
         Resource = [
@@ -283,6 +282,7 @@ resource "aws_iam_policy" "orchestrator_ecs_run_task" {
       {
         Effect = "Allow"
         Action = [
+          "ecs:StopTask",
           "ecs:TagResource",
         ]
         Resource = [

--- a/launch_system/orchestrator.tf
+++ b/launch_system/orchestrator.tf
@@ -272,7 +272,6 @@ resource "aws_iam_policy" "orchestrator_ecs_run_task" {
       {
         Effect = "Allow"
         Action = [
-          "ecs:DescribeTasks",
           "ecs:ListTasks",
         ]
         Resource = [
@@ -284,6 +283,7 @@ resource "aws_iam_policy" "orchestrator_ecs_run_task" {
         Action = [
           "ecs:StopTask",
           "ecs:TagResource",
+          "ecs:DescribeTasks",
         ]
         Resource = [
           "arn:aws:ecs:${var.aws_region}:${var.account_id}:task/${aws_ecs_cluster.executor.name}/*",


### PR DESCRIPTION
**Issue**
```
"An error occurred (AccessDeniedException) when calling the StopTask operation: User: arn:aws:sts::992382665735:assumed-role/launch_system_orchestrator20251120132453133200000007/a9bb7feea8e24e2ca40c8a8d2ea17f21 is not authorized to perform: ecs:StopTask on resource: arn:aws:ecs:us-east-1:992382665735:task/launch_system_executor/b93697d42e6c4afeba1ba9fba8985c85 because no identity-based policy allows the ecs:StopTask action"
```
Which is due to the wrong policy Resource pattern.

ecs:DescribeTasks seems misplaced too