### PR TITLE
Enable readonlyRootFilesystem for small_scale_simulator api service

### DIFF
--- a/small_scale_simulator/ecs.tf
+++ b/small_scale_simulator/ecs.tf
@@ -267,6 +267,10 @@ resource "aws_ecs_task_definition" "api" {
     }
   }
 
+  volume {
+    name = "tmp"
+  }
+
   container_definitions = jsonencode([
     {
       name  = "api"
@@ -274,6 +278,8 @@ resource "aws_ecs_task_definition" "api" {
 
       cpu    = var.api_task_size.cpu
       memory = var.api_task_size.memory
+
+      readonlyRootFilesystem = true
 
       stopTimeout = 120
 
@@ -289,6 +295,11 @@ resource "aws_ecs_task_definition" "api" {
         {
           sourceVolume  = "storage"
           containerPath = "/app/storage"
+          readOnly      = false
+        },
+        {
+          sourceVolume  = "tmp"
+          containerPath = "/tmp"
           readOnly      = false
         }
       ]


### PR DESCRIPTION
I checked the code and the apps need to write on /app/storage but that's already mounted as an external volume on EFS.

For https://github.com/openbraininstitute/INFRA/issues/391