### PR TITLE
Allow core web app preview role stop Amplify jobs

### DIFF
--- a/core_webapp_preview/main.tf
+++ b/core_webapp_preview/main.tf
@@ -198,6 +198,7 @@ resource "aws_iam_role_policy" "github_deploy" {
           "amplify:GetBranch",
           "amplify:ListBranches",
           "amplify:StartJob",
+          "amplify:StopJob",
           "amplify:GetJob",
           "amplify:ListJobs",
           "amplify:CreateDeployment",


### PR DESCRIPTION
So that CI can stop currently running builds for previous commits.