### PR TITLE
Set MPLCONFIGDIR to /tmp

### DIFF
--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -261,6 +261,10 @@ resource "aws_ecs_task_definition" "obi_one_v2_ecs_definition" {
         {
           name  = "ACCOUNTING_BASE_URL"
           value = var.accounting_base_url
+        },
+        {
+          name  = "MPLCONFIGDIR",
+          value = "/tmp/matplotlib"
         }
       ]
 


### PR DESCRIPTION
Fix this warning: 

> WARNING:matplotlib:Matplotlib created a temporary cache directory at /tmp/matplotlib-nvl135ar because there was an issue with the default path (/code/.config/matplotlib); it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.

I started after setting readonlyRootFilesystem to true