### PR TITLE
Upgrade staging small scale simulator to 2026.02.17.2

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -28,8 +28,8 @@ keycloak_url_with_auth = "https://staging.cell-a.openbraininstitute.org/auth/"
 
 neuroagent_docker_image_url = "985539765147.dkr.ecr.us-east-1.amazonaws.com/neuroagent:neuroagent-v0.16.0"
 
-small_scale_simulator_api_docker_image_url    = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2026.02.17.1"
-small_scale_simulator_worker_docker_image_url = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2026.02.17.1"
+small_scale_simulator_api_docker_image_url    = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2026.02.17.2"
+small_scale_simulator_worker_docker_image_url = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2026.02.17.2"
 small_scale_simulator_api_task_size = {
   cpu    = 256
   memory = 512


### PR DESCRIPTION
This reverts the config updates to make PyNWB and Matplotlib write to /tmp folder - which is not writable by a non-root user by default (and without corresponding infra changes).

Relates to https://github.com/openbraininstitute/prod-singlecell-simulation/issues/254#issuecomment-3897759632.