### PR TITLE
Revert "Ignore case when checking access to bastion"

### DIFF
--- a/bastion_host/iam_user_policy.tf
+++ b/bastion_host/iam_user_policy.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "ssm_user_access" {
           "arn:aws:ssm:*:${data.aws_caller_identity.current.account_id}:document/SSM-UserMapping-*"
         ]
         Condition = {
-          StringLikeIgnoreCase = {
+          StringLike = {
             "aws:userid" = "*:$${ssm:resourceTag/AllowedEmail}"
           }
         }


### PR DESCRIPTION
This reverts commit f648a76f2dcb2e1a68126fa9f3bec04d4be87c6d.

this change was in the end not needed. We fixed @DriesVerachtert's username directly on entraID and forced a resync