### PR TITLE
Add request_id to final_message in log processing

### DIFF
--- a/sns_entries_to_teams/src/aws_json_log_sns_to_teams.py
+++ b/sns_entries_to_teams/src/aws_json_log_sns_to_teams.py
@@ -88,6 +88,8 @@ def parse_log_event_json_to_readable_message(msg: Dict[str,Any]) -> str:
         final_message += f"Message: {msg['message']}\n\n"
     if "exception" in msg:
         final_message += f"Exception: {msg['exception']}\n\n"
+    if "extra" in msg and "request_id" in msg["extra"]:
+        final_message += f"Request id: {msg['extra']['request_id']}\n\n"
     return final_message
 
 def handle_eventbridge_cost_anomaly_event(event: Dict[str, Any], _) -> Dict[str, Any]:


### PR DESCRIPTION
Now the messages in entitycore (version 2026.2.5 deployed to staging) include:
- `request_id` (an internal uuid, unique per request and common to any other log in the same request)
- `user_id` (if the user has been authenticated).

We can add `request_id` to the notification to make it easier to retrieve the other logs when an investigation is needed.

Example in staging:

```json
{
  "time": "2026-02-25T08:14:53.744995+00:00",
  "level": "WARNING",
  "name": "app.application",
  "message": "API error in POST http://staging.cell-a.openbraininstitute.org/api/entitycore/circuit/1812069f-7b24-491c-b980-625fdd5ff3e4/assets: error_code=ASSET_INVALID_FILE message=File not allowed because empty or bigger than 524288000 details=None, cause: None",
  "extra": {
    "request_id": "f9b49b26-3dcf-493b-856d-b7f0dbdf03b6",
    "user_id": "e41b43dc-5078-40d5-a081-12bc031f3b17"
  },
  "exception": null
}
```