### PR TITLE
Fix the s3 bucket CORS for preview envs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ locals {
       "http://127.0.0.1:3000",
       "http://localhost:3000",
       "https://preview.openbraininstitute.org",
+      "https://*.preview.openbrainionstitute.org",
       "https://dev.openbraininstitute.org",
       "https://staging.cell-b.openbraininstitute.org",
       "https://staging.cell-a.openbraininstitute.org"


### PR DESCRIPTION
We had an issue with the preview branch. The plots where getting CORSed because of our s3 bucket not allowing the new : 
`[branch-name].preview.openbraininstitute.org/)` pattern