### PR TITLE
Allow the launch system API task to pull packages from CodeArtifact

### DIFF
--- a/launch_system/api.tf
+++ b/launch_system/api.tf
@@ -317,6 +317,32 @@ resource "aws_iam_role_policy_attachment" "api_secrets_access" {
   policy_arn = aws_iam_policy.secrets_access.arn
 }
 
+resource "aws_iam_policy" "api_codeartifact_read" {
+  name_prefix = "launch_system_api_codeartifact"
+  description = "Allow the launch system API task to pull packages from CodeArtifact"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sts:GetServiceBearerToken",
+          "codeartifact:GetAuthorizationToken",
+          "codeartifact:GetRepositoryEndpoint",
+          "codeartifact:ReadFromRepository",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "api_codeartifact_read" {
+  role       = aws_iam_role.api_task.name
+  policy_arn = aws_iam_policy.api_codeartifact_read.arn
+}
+
 resource "aws_iam_role_policy_attachment" "api_logs_access" {
   role       = aws_iam_role.api_execution.name
   policy_arn = aws_iam_policy.api_logs_access.arn


### PR DESCRIPTION

Example of usage from the task's code:
```python
import boto3
import subprocess

def get_codeartifact_token():
    client = boto3.client("codeartifact", region_name="us-east-1")
    response = client.get_authorization_token(
        domain="openbraininstitute",
        domainOwner="985539765147",
        durationSeconds=43200  # 12 hours
    )
    return response["authorizationToken"]

token = get_codeartifact_token()
index_url = f"https://aws:{token}@openbraininstitute-985539765147.d.codeartifact.us-east-1.amazonaws.com/pypi/pypi-prod/simple/"

subprocess.run([
    "pip", "install", "ultraliser",
    "--index-url", index_url
], check=True)
```