### PR TITLE
Set engine_version to 17.9

### DIFF
--- a/virtual-lab-manager/db.tf
+++ b/virtual-lab-manager/db.tf
@@ -40,7 +40,7 @@ resource "aws_db_instance" "virtual_lab_manager" {
   db_subnet_group_name = aws_db_subnet_group.virtual_lab_manager_db_subnet_group.name
 
   engine                     = "postgres"
-  engine_version             = "17"
+  engine_version             = "17.9"
   auto_minor_version_upgrade = true
   multi_az                   = var.db_multi_az
   instance_class             = "db.t3.small"


### PR DESCRIPTION
To avoid
```
│ Error: updating RDS DB Instance (virtual-lab-manager-db-id): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: a0b75f4c-7349-4b59-a41a-42c2c447ecde, api error InvalidParameterCombination: Cannot upgrade postgres from 17.9 to 17.6
│ 
│   with module.virtual_lab_manager.aws_db_instance.virtual_lab_manager,
│   on virtual-lab-manager/db.tf line 30, in resource "aws_db_instance" "virtual_lab_manager":
│   30: resource "aws_db_instance" "virtual_lab_manager" {
```