### PR TITLE
entitycore: increase db migration timeouts

### DIFF
--- a/entitycore_svc/backend.tf
+++ b/entitycore_svc/backend.tf
@@ -164,6 +164,14 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
           name  = "API_ASSET_POST_MAX_SIZE"
           value = var.api_asset_post_max_size
         },
+        {
+          name  = "DB_MIGRATION_STATEMENT_TIMEOUT_MS"
+          value = var.db_migration_statement_timeout_ms
+        },
+        {
+          name  = "DB_MIGRATION_LOCK_TIMEOUT_MS"
+          value = var.db_migration_lock_timeout_ms
+        },
       ]
 
       secrets = [

--- a/entitycore_svc/variables.tf
+++ b/entitycore_svc/variables.tf
@@ -92,3 +92,13 @@ variable "api_asset_post_max_size" {
   description = "Maximum size of file uploaded through API"
   type        = string
 }
+
+variable "db_migration_statement_timeout_ms" {
+  description = "Abort any statement that takes more than the specified amount of time"
+  type        = string
+}
+
+variable "db_migration_lock_timeout_ms" {
+  description = "Abort any statement that waits longer than the specified amount of time"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -676,6 +676,9 @@ module "entitycore_svc" {
   db_name     = "entitycore"
   db_username = "entitycore"
 
+  db_migration_statement_timeout_ms = 60000
+  db_migration_lock_timeout_ms      = 10000
+
   obi_backup_plan = "obi_plan"
 
   api_asset_post_max_size = "524288000" # 500 * 1024**2


### PR DESCRIPTION
The deployment to staging fails for a timeout, so increasing:

- DB_MIGRATION_STATEMENT_TIMEOUT_MS: 30000 -> 60000
- DB_MIGRATION_LOCK_TIMEOUT_MS: 5000 -> 10000

Error:
> sqlalchemy.exc.OperationalError: (psycopg2.errors.QueryCanceled) canceling statement due to statement timeout

from https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/entitycore_ecs_cluster/services/entitycore_ecs_service/tasks/b990b45b344f4162ba8bd7e20a504c55/logs?region=us-east-1