### PR TITLE
Only set CORS_ORIGIN_REGEX if value not null

### DIFF
--- a/entitycore_svc/backend.tf
+++ b/entitycore_svc/backend.tf
@@ -103,7 +103,7 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
         retries     = 3
       }
 
-      environment = [
+      environment = concat([
         {
           name  = "APP_DEBUG"
           value = "false"
@@ -111,10 +111,6 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
         {
           name  = "CORS_ORIGINS"
           value = jsonencode(var.cors_origins)
-        },
-        {
-          name  = "CORS_ORIGIN_REGEX"
-          value = var.cors_origin_regex
         },
         {
           name  = "KEYCLOAK_URL"
@@ -180,7 +176,7 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
           name  = "DB_MIGRATION_LOCK_TIMEOUT_MS"
           value = var.db_migration_lock_timeout_ms
         },
-      ]
+      ], var.cors_origin_regex != null ? [{ name = "CORS_ORIGIN_REGEX", value = var.cors_origin_regex }] : [])
 
       secrets = [
         {

--- a/obi_one_v2/container.tf
+++ b/obi_one_v2/container.tf
@@ -225,7 +225,7 @@ resource "aws_ecs_task_definition" "obi_one_v2_ecs_definition" {
         ]
       }
 
-      environment = [
+      environment = concat([
         {
           name  = "APP_DEBUG"
           value = "false"
@@ -233,10 +233,6 @@ resource "aws_ecs_task_definition" "obi_one_v2_ecs_definition" {
         {
           name  = "CORS_ORIGINS"
           value = jsonencode(var.cors_origins)
-        },
-        {
-          name  = "CORS_ORIGIN_REGEX"
-          value = var.cors_origin_regex
         },
         {
           name  = "ROOT_PATH"
@@ -270,7 +266,7 @@ resource "aws_ecs_task_definition" "obi_one_v2_ecs_definition" {
           name  = "MPLCONFIGDIR",
           value = "/tmp/matplotlib"
         }
-      ]
+      ], var.cors_origin_regex != null ? [{ name = "CORS_ORIGIN_REGEX", value = var.cors_origin_regex }] : [])
 
       healthcheck = {
         # command     = ["CMD", "/code/scripts/healthcheck.sh"]

--- a/small_scale_simulator/ecs.tf
+++ b/small_scale_simulator/ecs.tf
@@ -326,7 +326,7 @@ resource "aws_ecs_task_definition" "api" {
           readOnly      = false
         }
       ]
-      environment = [
+      environment = concat([
         {
           name  = "REDIS_URL"
           value = "redis://redis.small-scale-simulator.local:6379"
@@ -342,10 +342,6 @@ resource "aws_ecs_task_definition" "api" {
         {
           name  = "CORS_ORIGINS"
           value = jsonencode(var.cors_origins)
-        },
-        {
-          name  = "CORS_ORIGIN_REGEX"
-          value = var.cors_origin_regex
         },
         {
           name  = "KC_SERVER_URI"
@@ -379,7 +375,7 @@ resource "aws_ecs_task_definition" "api" {
           name  = "METRICS_AWS_REGION"
           value = var.aws_region
         }
-      ]
+      ], var.cors_origin_regex != null ? [{ name = "CORS_ORIGIN_REGEX", value = var.cors_origin_regex }] : [])
 
       secrets = [
         {

--- a/thumbnail-generation-api/container.tf
+++ b/thumbnail-generation-api/container.tf
@@ -208,7 +208,7 @@ resource "aws_ecs_task_definition" "main" {
             protocol      = "tcp"
           }
         ],
-        environment = [
+        environment = concat([
           {
             name  = "WHITELISTED_CORS_URLS",
             value = jsonencode(var.cors_origins)
@@ -216,10 +216,6 @@ resource "aws_ecs_task_definition" "main" {
           {
             name  = "BASE_PATH"
             value = var.base_path
-          },
-          {
-            name  = "CORS_ORIGIN_REGEX"
-            value = var.cors_origin_regex
           },
           {
             name  = "ENVIRONMENT"
@@ -237,7 +233,7 @@ resource "aws_ecs_task_definition" "main" {
             name  = "MPLCONFIGDIR",
             value = "/tmp/matplotlib"
           },
-        ],
+        ], var.cors_origin_regex != null ? [{ name = "CORS_ORIGIN_REGEX", value = var.cors_origin_regex }] : []),
         memory = 2048
         cpu    = 1024
         logConfiguration = {

--- a/virtual-lab-manager/container.tf
+++ b/virtual-lab-manager/container.tf
@@ -118,7 +118,7 @@ resource "aws_ecs_task_definition" "virtual_lab_manager_ecs_definition" {
         startPeriod = 30
         retries     = 3
       }
-      environment = [
+      environment = concat([
         {
           name  = "DEBUG"
           value = "true"
@@ -192,10 +192,6 @@ resource "aws_ecs_task_definition" "virtual_lab_manager_ecs_definition" {
           value = jsonencode(var.cors_origins)
         },
         {
-          name  = "CORS_ORIGIN_REGEX"
-          value = var.cors_origin_regex
-        },
-        {
           name  = "VLAB_ADMIN_PATH"
           value = var.virtual_lab_manager_admin_base_path
         },
@@ -243,8 +239,7 @@ resource "aws_ecs_task_definition" "virtual_lab_manager_ecs_definition" {
           name  = "MAX_PROJECTS_NUMBER"
           value = "40"
         },
-
-      ]
+      ], var.cors_origin_regex != null ? [{ name = "CORS_ORIGIN_REGEX", value = var.cors_origin_regex }] : [])
       secrets = [
         {
           name      = "KC_CLIENT_ID"


### PR DESCRIPTION
`CORS_ORIGIN_REGEX` is only set in the staging environment. During production deployments, Terraform detects it as a new environment variable in the task definition (see https://github.com/openbraininstitute/aws-terraform-deployment/actions/runs/23046619808/job/66937206141#step:8:1858)

However, because its value is empty in production, it is not actually added to the container. 

This mismatch causes Terraform to believe the task definition has changed, which results in all containers that reference CORS_ORIGIN_REGEX being restarted.

```
                      + {
                          + name = "CORS_ORIGIN_REGEX"
                        },
```

This change fixes that.