### PR TITLE
DEV corewebapp can't fetch the notebook image anymore: make sure ephemeral tcp ports are allowed from everyone as its needed to access the public ECR

### DIFF
--- a/core_webapp/subnet.tf
+++ b/core_webapp/subnet.tf
@@ -31,8 +31,16 @@ resource "aws_network_acl" "core_webapp" {
   ingress {
     protocol   = "tcp"
     rule_no    = 300
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3389
+    to_port    = 3389
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 400
     action     = "allow"
-    cidr_block = var.vpc_cidr_block
+    cidr_block = "0.0.0.0/0"
     from_port  = 1024
     to_port    = 65535
   }


### PR DESCRIPTION
https://github.com/openbraininstitute/INFRA/issues/480
