### PR TITLE
Set slurm purge time to 60 days instead of infinite

### DIFF
--- a/launch_system/pcs.tf
+++ b/launch_system/pcs.tf
@@ -16,7 +16,7 @@ resource "awscc_pcs_cluster" "cluster" {
   size = "SMALL"
   slurm_configuration = {
     accounting = {
-      default_purge_time_in_days = -1
+      default_purge_time_in_days = 60
       mode                       = "NONE"
     }
     scale_down_idle_time_in_seconds = 600


### PR DESCRIPTION
Infinite may be a bit generous. There also seems to be a mismatch between how awscc expects this setting (-1 = infinity) and how AWS stores it (no value = infinity), causing it to be re-applied on every deployment. Since PCS through awscc is dramatically slow, this is undesirable. Maybe even sub-awesome, so let's set it to something reasonable.