### PR TITLE
entitycore: allow s3:DeleteObjectVersion

### DIFF
--- a/entitycore_svc/policies.tf
+++ b/entitycore_svc/policies.tf
@@ -34,6 +34,7 @@ resource "aws_iam_policy" "s3_access" {
           "s3:PutObject",
           "s3:GetObject",
           "s3:DeleteObject",
+          "s3:DeleteObjectVersion",
           "s3:ListBucket"
         ]
         Resource = [


### PR DESCRIPTION
Add s3:DeleteObjectVersion to entitycore for its bucket.
This is needed to "move" (copy and hard delete, without leaving a versioned copy that would duplicate the used storage) an object in the S3 bucket from the private to the public directory, see https://github.com/openbraininstitute/prod-platform-architecture/issues/192

cc @jdcourcol 