### PR TITLE
Upgrade staging small scale simulator to 2026.03.26.1

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -27,8 +27,8 @@ keycloak_url_with_auth = "https://staging.cell-a.openbraininstitute.org/auth/"
 
 neuroagent_docker_image_url = "985539765147.dkr.ecr.us-east-1.amazonaws.com/neuroagent:neuroagent-v0.17.1"
 
-small_scale_simulator_api_docker_image_url    = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2026.03.25.2"
-small_scale_simulator_worker_docker_image_url = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2026.03.25.2"
+small_scale_simulator_api_docker_image_url    = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2026.03.26.1"
+small_scale_simulator_worker_docker_image_url = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2026.03.26.1"
 small_scale_simulator_api_task_size = {
   cpu    = 256
   memory = 512


### PR DESCRIPTION
This version contains a hot fix for https://github.com/openbraininstitute/prod-singlecell-simulation/issues/267