### PR TITLE
launch_system: turn on slurm accounting

### DIFF
--- a/launch_system/pcs.tf
+++ b/launch_system/pcs.tf
@@ -15,6 +15,10 @@ resource "awscc_pcs_cluster" "cluster" {
   }
   size = "SMALL"
   slurm_configuration = {
+    accounting = {
+      default_purge_time_in_days = 60
+      mode                       = "STANDARD"
+    }
     scale_down_idle_time_in_seconds = 600
     slurm_custom_settings = [
       {


### PR DESCRIPTION
* To be able to see the status of jobs that have run, one needs to have accounting enabled
* by default, on PCS, slurm has `MinJobAge=300`; so after 5 minutes the information is gone