### PR TITLE
Core Web app preview deployments: use staging keycloak client

### DIFF
--- a/core_webapp_preview/main.tf
+++ b/core_webapp_preview/main.tf
@@ -70,7 +70,7 @@ resource "aws_amplify_app" "this" {
     SANITY_DATASET         = var.sanity_dataset
     STRIPE_PUBLISHABLE_KEY = var.stripe_publishable_key
     KEYCLOAK_CLIENT_ID     = var.keycloak_client_id
-    KEYCLOAK_CLIENT_SECRET = jsondecode(data.aws_secretsmanager_secret_version.secrets.secret_string)["client_secret_preview"]
+    KEYCLOAK_CLIENT_SECRET = jsondecode(data.aws_secretsmanager_secret_version.secrets.secret_string)["client_secret_cellb_azure_staging"]
     NEXTAUTH_SECRET        = jsondecode(data.aws_secretsmanager_secret_version.secrets.secret_string)["nextauth_secret"]
     AUTH_PROXY_URL         = "https://develop.${var.domain_name}"
   }

--- a/core_webapp_preview/variables.tf
+++ b/core_webapp_preview/variables.tf
@@ -48,7 +48,6 @@ variable "keycloak_issuer" {
 variable "keycloak_client_id" {
   type        = string
   description = "Keycloak client ID"
-  default     = "core-webapp-preview"
 }
 
 variable "sanity_dataset" {

--- a/main.tf
+++ b/main.tf
@@ -604,6 +604,7 @@ module "core_webapp_preview" {
   api_origin             = "https://${local.cell_a_primary_domain}"
   deployment_env         = "preview"
   keycloak_issuer        = var.keycloak_sbo_realm_url
+  keycloak_client_id     = var.keycloak_client_id
   sanity_dataset         = "staging"
   stripe_publishable_key = var.core_web_app_stripe_publishable_key
 }


### PR DESCRIPTION
That is needed to make preview deployment work with the auth-manager (Keycloak client should match) so that we can test submitting jobs which require offline tokens.