### PR TITLE
launch-system: change PCS cluster to allow oomkill

### DIFF
--- a/launch_system/pcs.tf
+++ b/launch_system/pcs.tf
@@ -23,7 +23,7 @@ resource "awscc_pcs_cluster" "cluster" {
     slurm_custom_settings = [
       {
         parameter_name  = "SelectTypeParameters"
-        parameter_value = "CR_CPU"
+        parameter_value = "CR_CPU_Memory"
       },
     ]
     slurm_rest = {


### PR DESCRIPTION
* without `SelectTypeParameters` the `MemSpecLimit` will not have OOM kills