### PR TITLE
Delete core_webapp_s3_bucket_name references from ftvars

### DIFF
--- a/production.tfvars
+++ b/production.tfvars
@@ -122,7 +122,6 @@ obi_one_v2_ecs_task_size = {
 }
 
 # CoreWebApp s3 and CloudFront configuration
-core_webapp_s3_bucket_name = "core-webapp-static-assets-production"
 auth_manager_svc_image_url = "985539765147.dkr.ecr.us-east-1.amazonaws.com/auth-manager:2026.02.12.2"
 keycloak_client_uuid       = "5c060da0-5f9f-4a35-b9fd-32c5fafb1aca"
 keycloak_client_id         = "core-webapp-cell-b-azure"

--- a/sandbox-benchmarks.tfvars
+++ b/sandbox-benchmarks.tfvars
@@ -111,7 +111,6 @@ obi_one_v2_ecs_task_size = {
 }
 
 # CoreWebApp s3 and CloudFront configuration
-core_webapp_s3_bucket_name = "core-webapp-static-assets-production"
 
 core_web_app_in_azure_cidr_block = "10.102.1.0/27" # staging azure core web app aca range
 auth_manager_svc_image_url       = "985539765147.dkr.ecr.us-east-1.amazonaws.com/auth-manager:2025.12.12.1"

--- a/sandbox-hpc.tfvars
+++ b/sandbox-hpc.tfvars
@@ -108,7 +108,6 @@ obi_one_v2_ecs_task_size = {
 }
 
 # CoreWebApp s3 and CloudFront configuration
-core_webapp_s3_bucket_name = "core-webapp-static-assets-sandbox-hpc"
 auth_manager_svc_image_url = "985539765147.dkr.ecr.us-east-1.amazonaws.com/auth-manager:2025.10.28.1"
 keycloak_client_uuid       = "569228c5-674f-4f54-b9cb-8d179be66bda"
 keycloak_client_id         = "core-webapp-dev"

--- a/sandbox-nse.tfvars
+++ b/sandbox-nse.tfvars
@@ -93,6 +93,5 @@ obi_one_v2_ecs_task_size = {
 }
 
 # CoreWebApp s3 and CloudFront configuration
-core_webapp_s3_bucket_name = "core-webapp-static-assets-production"
 
 core_web_app_in_azure_cidr_block = "10.102.1.0/27" # staging azure core web app aca range

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -123,7 +123,6 @@ obi_one_v2_ecs_task_size = {
 }
 
 # CoreWebApp s3 and CloudFront configuration
-core_webapp_s3_bucket_name = "core-webapp-static-assets-staging"
 auth_manager_svc_image_url = "985539765147.dkr.ecr.us-east-1.amazonaws.com/auth-manager:2026.04.08.1"
 keycloak_client_uuid       = "a40fd6ea-79f8-4212-b087-45c75e4703a4"
 keycloak_client_id         = "core-webapp-cell-b-azure-staging"


### PR DESCRIPTION
Variable deleted in 0915cb8309060c78a25885be5e77c7a413ebf778

and now we are getting this warning:
```
│ Warning: Value for undeclared variable
│ 
│ The root module does not declare a variable named
│ "core_webapp_s3_bucket_name" but a value was found in file
│ "staging.tfvars". If you meant to use this value, add a "variable" block to
│ the configuration.
```