### PR TITLE
Revert "launch_system: switch to hpc7a.96xlarge (#1323)"

### DIFF
--- a/launch_system/pcs.tf
+++ b/launch_system/pcs.tf
@@ -188,7 +188,7 @@ resource "awscc_pcs_compute_node_group" "pcs_nodegroup_large" {
 
   instance_configs = [
     {
-      instance_type = "hpc7a.96xlarge"
+      instance_type = "c8a.48xlarge"
     },
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -954,7 +954,6 @@ module "launch_system" {
   pcs_large_alternate_node_types = [
     # Note: since our account quota doesn't allow 192CPU * 20 [max count] * (1[above] + 4[below])
     # the following are capped at 1 node each, and don't participate in the `fallback` - mgevaert
-    #"c8a.48xlarge",
     "c8i.48xlarge",
     "c7a.48xlarge",
     "c7i.48xlarge",


### PR DESCRIPTION
This reverts commit 03f0f9939a687e55416cc1f0f27e072cd5ec039f.

```
StatusMessage: Invalid
│ instanceConfigs: Invalid instance type in [hpc7a.96xlarge] (Service: Pcs,
│ Status Code: 400, Request ID: d31712d0-8d53-4e82-9079-91da992e2dc1) (SDK
│ Attempt Count: 1). ErrorCode: InvalidRequest
```