### PR TITLE
update bluenaas version

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -31,8 +31,8 @@ ml_typescript_subnet_a_cidr            = "10.0.9.0/24"
 ml_typescript_subnet_b_cidr            = "10.0.7.0/24"
 grading_service_docker_image_url       = "985539765147.dkr.ecr.us-east-1.amazonaws.com/grading-service:latest"
 
-small_scale_simulator_api_docker_image_url    = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2026.04.27.1"
-small_scale_simulator_worker_docker_image_url = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2026.04.27.1"
+small_scale_simulator_api_docker_image_url    = "public.ecr.aws/openbraininstitute/single-cell-simulator:api-2026.04.30.1"
+small_scale_simulator_worker_docker_image_url = "public.ecr.aws/openbraininstitute/single-cell-simulator:worker-2026.04.30.1"
 small_scale_simulator_api_task_size = {
   cpu    = 256
   memory = 512


### PR DESCRIPTION
this is needed to run simulations with multi-levels seclamp.
UI implementation: https://github.com/openbraininstitute/prod-build-ion-channel-model/issues/104
obi-one implementation: https://github.com/openbraininstitute/obi-one/pull/600
bluenaas' obi-one dependency update: https://github.com/openbraininstitute/Bluenaas/pull/153