### PR TITLE
Allow NFS traffic from EKS private subnets to keycloak-providers EFS

### DIFF
--- a/cs/jupyterhub_eks/subnets.tf
+++ b/cs/jupyterhub_eks/subnets.tf
@@ -394,6 +394,29 @@ resource "aws_network_acl_rule" "jupyterhub_eks_private_launch_data_efs_ingress2
   egress         = false
 }
 
+# Allow NFS response traffic from keycloak-providers EFS mount targets
+resource "aws_network_acl_rule" "jupyterhub_eks_private_keycloak_providers_efs_ingress_a" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_private.id
+  rule_number    = 42
+  protocol       = "tcp"
+  from_port      = 1024
+  to_port        = 65535
+  rule_action    = "allow"
+  cidr_block     = var.keycloak_subnet_cidr_a
+  egress         = false
+}
+
+resource "aws_network_acl_rule" "jupyterhub_eks_private_keycloak_providers_efs_ingress_b" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_private.id
+  rule_number    = 43
+  protocol       = "tcp"
+  from_port      = 1024
+  to_port        = 65535
+  rule_action    = "allow"
+  cidr_block     = var.keycloak_subnet_cidr_b
+  egress         = false
+}
+
 
 resource "aws_network_acl_rule" "jupyterhub_eks_private_nat_gateway_ingress" {
   network_acl_id = aws_network_acl.jupyterhub_eks_private.id
@@ -576,6 +599,29 @@ resource "aws_network_acl_rule" "jupyterhub_eks_private_access_to_public_launch_
   to_port        = 2049
   rule_action    = "allow"
   cidr_block     = var.public_data_efs_ip_address2_as_cidr
+  egress         = true
+}
+
+# Allow NFS egress to keycloak-providers EFS mount targets
+resource "aws_network_acl_rule" "jupyterhub_eks_private_access_to_keycloak_providers_nfs_a" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_private.id
+  rule_number    = 42
+  protocol       = "tcp"
+  from_port      = 2049
+  to_port        = 2049
+  rule_action    = "allow"
+  cidr_block     = var.keycloak_subnet_cidr_a
+  egress         = true
+}
+
+resource "aws_network_acl_rule" "jupyterhub_eks_private_access_to_keycloak_providers_nfs_b" {
+  network_acl_id = aws_network_acl.jupyterhub_eks_private.id
+  rule_number    = 43
+  protocol       = "tcp"
+  from_port      = 2049
+  to_port        = 2049
+  rule_action    = "allow"
+  cidr_block     = var.keycloak_subnet_cidr_b
   egress         = true
 }
 

--- a/cs/jupyterhub_eks/variables.tf
+++ b/cs/jupyterhub_eks/variables.tf
@@ -120,6 +120,18 @@ variable "bastion_instance_private_ip" {
   description = "Private IP of the bastion instance, needed to allow access to the test vm for filesystems"
 }
 
+variable "keycloak_subnet_cidr_a" {
+  description = "CIDR of the first keycloak subnet, needed for NFS access to keycloak-providers EFS"
+  type        = string
+  sensitive   = false
+}
+
+variable "keycloak_subnet_cidr_b" {
+  description = "CIDR of the second keycloak subnet, needed for NFS access to keycloak-providers EFS"
+  type        = string
+  sensitive   = false
+}
+
 variable "s3_bucket_entitycore_data_name" {
   type        = string
   description = "The S3 bucket that will be associated with the lustre fileystems"

--- a/cs/main.tf
+++ b/cs/main.tf
@@ -58,6 +58,9 @@ module "jupyterhub_eks" {
   public_data_efs_ip_address2_as_cidr = var.public_data_efs_ip_address2_as_cidr
   bastion_instance_private_ip         = var.bastion_instance_private_ip
 
+  keycloak_subnet_cidr_a = module.networking.keycloak_subnet_cidr_a
+  keycloak_subnet_cidr_b = module.networking.keycloak_subnet_cidr_b
+
   # Only used in staging
   is_lustre_filesystem_enabled = false
   # As a test, mount the s3 bucket with the shared data for jupyterhub

--- a/cs/networking/output.tf
+++ b/cs/networking/output.tf
@@ -9,3 +9,11 @@ output "jupyterhub_private_subnet" {
 output "secret_sharing_svc_private_subnet" {
   value = aws_subnet.cs_secret_sharing_svc_subnet.id
 }
+
+output "keycloak_subnet_cidr_a" {
+  value = aws_subnet.cs_subnet_a.cidr_block
+}
+
+output "keycloak_subnet_cidr_b" {
+  value = aws_subnet.cs_subnet_b.cidr_block
+}


### PR DESCRIPTION
Add NACL rules on jupyterhub_eks_private to permit NFS (port 2049) egress and ephemeral port ingress to/from the keycloak subnets, enabling EFS CSI driver mounts from EKS runner pods.

for https://github.com/openbraininstitute/INFRA/issues/520