### PR TITLE
Revert "AWS wants us to try `hpc7a.96xlarge` in PCS again (#1352)"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1013,8 +1013,7 @@ module "launch_system" {
     "c8i.48xlarge",
     "c7a.48xlarge",
     "c7i.48xlarge",
-    #"c6a.48xlarge",
-    "hpc7a.96xlarge "
+    "c6a.48xlarge",
     # no such thing as c6i.48xlarge
   ]
 


### PR DESCRIPTION
It didn't work:
```
│ Error: AWS SDK Go Service Operation Incomplete
│
│   with module.launch_system.awscc_pcs_compute_node_group.pcs_ng_large_fallback["alt3"],
│   on launch_system/pcs.tf line 231, in resource "awscc_pcs_compute_node_group" "pcs_ng_large_fallback":
│  231: resource "awscc_pcs_compute_node_group" "pcs_ng_large_fallback" {
│
│ Waiting for Cloud Control API service CreateResource operation completion
│ returned: waiter state transitioned to FAILED. StatusMessage: Invalid
│ instanceConfigs: Invalid instance type in [hpc7a.96xlarge ] (Service: Pcs,
│ Status Code: 400, Request ID: 8c74e938-9d2b-4137-85f9-0ea8a603352c) (SDK
│ Attempt Count: 1). ErrorCode: InvalidRequest
```

This reverts commit 9ecc4da75adef6b37eba66a366551b5d18e48763.