### PR TITLE
Core Web app preview: fix GH deploy role ACLs

### DIFF
--- a/core_webapp_preview/main.tf
+++ b/core_webapp_preview/main.tf
@@ -229,16 +229,16 @@ resource "aws_iam_role_policy" "github_deploy" {
           "amplify:GetJob",
           "amplify:ListJobs",
           "amplify:CreateDeployment",
-          "amplify:StartDeployment",
-          "amplify:GetDomainAssociation",
-          "amplify:UpdateDomainAssociation"
+          "amplify:StartDeployment"
         ]
         Resource = "${aws_amplify_app.this.arn}/*"
       },
       {
         Effect = "Allow"
         Action = [
-          "amplify:GetApp"
+          "amplify:GetApp",
+          "amplify:GetDomainAssociation",
+          "amplify:UpdateDomainAssociation"
         ]
         Resource = aws_amplify_app.this.arn
       }


### PR DESCRIPTION
It seems for `Get/UpdateDomainAssociation` the IAM authorization is evaluated against the app resource (apps/APP_ID) - the app ARN without a trailing segment - not against the domain sub-resource.