### PR TITLE
Fix undefined provider warnings

### DIFF
--- a/launch_system/provider.tf
+++ b/launch_system/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/public_data_efs_storage/provider.tf
+++ b/public_data_efs_storage/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/public_data_sync_opendata/provider.tf
+++ b/public_data_sync_opendata/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.uswest2]
+    }
+    awscc = {
+      source                = "hashicorp/awscc"
+      configuration_aliases = [awscc.uswest2]
+    }
+  }
+}


### PR DESCRIPTION
Fixes all the occurrences of this warning happening on every single terraform run:
```
│ Warning: Reference to undefined provider
│
│   on main.tf line 967, in module "public_data_sync_opendata":
│  967:     aws           = aws
│
│ There is no explicit declaration for local provider name "aws" in module.public_data_sync_opendata, so Terraform is assuming you mean to pass a configuration for "hashicorp/aws".
│
│ If you also control the child module, add a required_providers entry named "aws" with the source address "hashicorp/aws".
│
│ (and 3 more similar warnings elsewhere)
```