### PR TITLE
Initial setup for internal entitycore data sync

### DIFF
--- a/entitycore_svc/s3.tf
+++ b/entitycore_svc/s3.tf
@@ -53,39 +53,7 @@ resource "aws_s3_bucket_public_access_block" "entitycore" {
 resource "aws_s3_bucket_policy" "prevent_delete" {
   bucket = aws_s3_bucket.entitycore.id
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "DenyInsecureTransport"
-        Effect    = "Deny"
-        Principal = "*"
-        Action    = "s3:*"
-        Resource = [
-          aws_s3_bucket.entitycore.arn,
-          "${aws_s3_bucket.entitycore.arn}/*"
-        ]
-        Condition = {
-          Bool = {
-            "aws:SecureTransport" = "false"
-          }
-        }
-      },
-      {
-        Sid       = "PreventDeleteBucketAndObjects"
-        Effect    = "Deny"
-        Principal = "*"
-        Action = [
-          "s3:DeleteBucket",
-          "s3:DeleteBucketPolicy"
-        ]
-        Resource = [
-          aws_s3_bucket.entitycore.arn,
-          "${aws_s3_bucket.entitycore.arn}/*"
-        ]
-      },
-    ]
-  })
+  policy = templatefile(var.source_datasync_role == "" ? "${path.module}/s3_bucket_policy_without_datasync_source.tftpl" : "${path.module}/s3_bucket_policy_with_datasync_source.tftpl", { "source_datasync_role" = var.source_datasync_role, "aws_s3_bucket_entitycore_arn" = aws_s3_bucket.entitycore.arn })
 }
 
 resource "aws_s3_bucket_metric" "entitycore-metrics" {

--- a/entitycore_svc/s3_bucket_policy_with_datasync_source.tftpl
+++ b/entitycore_svc/s3_bucket_policy_with_datasync_source.tftpl
@@ -1,0 +1,54 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "DenyInsecureTransport",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "${aws_s3_bucket_entitycore_arn}",
+          "${aws_s3_bucket_entitycore_arn}/*"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        }
+      },
+      {
+        "Sid": "PreventDeleteBucketAndObjects",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": [
+          "s3:DeleteBucket",
+          "s3:DeleteBucketPolicy"
+        ],
+        "Resource": [
+          "${aws_s3_bucket_entitycore_arn}",
+          "${aws_s3_bucket_entitycore_arn}/*"
+        ]
+      },
+      {
+        "Sid": "DataSyncCreateS3LocationAndTaskAccess",
+        "Effect": "Allow",
+        "Principal": { "AWS": "${source_datasync_role}" },
+        "Action": [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:GetObjectTagging",
+          "s3:PutObjectTagging"
+        ],
+        "Resource": [
+          "${aws_s3_bucket_entitycore_arn}",
+          "${aws_s3_bucket_entitycore_arn}/*"
+        ]
+      }
+    ]
+  }

--- a/entitycore_svc/s3_bucket_policy_without_datasync_source.tftpl
+++ b/entitycore_svc/s3_bucket_policy_without_datasync_source.tftpl
@@ -1,0 +1,34 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "DenyInsecureTransport",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "${aws_s3_bucket_entitycore_arn}",
+          "${aws_s3_bucket_entitycore_arn}/*"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        }
+      },
+      {
+        "Sid": "PreventDeleteBucketAndObjects",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": [
+          "s3:DeleteBucket",
+          "s3:DeleteBucketPolicy"
+        ],
+        "Resource": [
+          "${aws_s3_bucket_entitycore_arn}",
+          "${aws_s3_bucket_entitycore_arn}/*"
+        ]
+      }
+    ]
+  }
+

--- a/entitycore_svc/variables.tf
+++ b/entitycore_svc/variables.tf
@@ -112,3 +112,9 @@ variable "db_migration_lock_timeout_ms" {
   description = "Abort any statement that waits longer than the specified amount of time"
   type        = string
 }
+
+variable "source_datasync_role" {
+  description = "IAM role to allow datasync to write to the S3 bucket. Should exist in the source account data comes from"
+  type        = string
+  default     = ""
+}

--- a/main.tf
+++ b/main.tf
@@ -566,6 +566,8 @@ module "entitycore_svc" {
   obi_backup_plan = "obi_plan"
 
   api_asset_post_max_size = "524288000" # 500 * 1024**2
+
+  source_datasync_role = var.source_datasync_role
 }
 module "auth_manager" {
   source = "./auth-manager"
@@ -778,6 +780,10 @@ module "public_data_sync_opendata" {
   azure_nfs_server_hostname                   = var.azure_nfs_server_hostname
   azure_nfs_opendata_path                     = var.azure_nfs_opendata_path
   azure_nfs_internal_public_data_path         = var.azure_nfs_internal_public_data_path
+
+  datasync_target_account                = var.datasync_target_account
+  destination_entitycore_internal_bucket = var.destination_entitycore_internal_bucket
+
 
   providers = {
     aws           = aws

--- a/production.tfvars
+++ b/production.tfvars
@@ -170,3 +170,6 @@ resource_provisioner_container_hash = "1837363b2413d5e7cfd8c7a859ba4b3cd35c685ac
 resource_provisioner_container_uri  = "985539765147.dkr.ecr.us-east-1.amazonaws.com/hpc-resource-provisioner:0.5.13.dev8"
 
 pcs_ami = "ami-0cfcd37a2d4cec1dc"
+
+datasync_target_account                = "992382665735"
+destination_entitycore_internal_bucket = "entitycore-data-staging"

--- a/public_data_sync_opendata/datasync.tf
+++ b/public_data_sync_opendata/datasync.tf
@@ -2,57 +2,6 @@ locals {
   opendata_paths = trim(replace(file("${path.module}/${var.opendata_paths_list}"), "\n", "|"), "|")
 }
 
-resource "aws_iam_role" "datasync_s3_role" {
-  name = "datasync-s3-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "datasync.amazonaws.com"
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy" "datasync_s3_policy" {
-  name = "datasync-s3-policy"
-  role = aws_iam_role.datasync_s3_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetBucketLocation",
-          "s3:ListBucket",
-          "s3:ListBucketMultipartUploads",
-          "s3:AbortMultipartUpload",
-          "s3:DeleteObject",
-          "s3:GetObject",
-          "s3:ListMultipartUploadParts",
-          "s3:PutObject",
-          "s3:GetObjectVersion",
-          "s3:GetObjectVersionTagging",
-          "s3:GetObjectTagging",
-          "s3:PutObjectTagging"
-        ]
-        Resource = [
-          "arn:aws:s3:::${var.entitycore_internal_bucket}",
-          "arn:aws:s3:::${var.entitycore_internal_bucket}/*",
-          "arn:aws:s3:::${var.opendata_bucket}",
-          "arn:aws:s3:::${var.opendata_bucket}/*"
-        ]
-      }
-    ]
-  })
-}
-
 resource "aws_datasync_location_s3" "internal_source" {
   s3_bucket_arn = "arn:aws:s3:::${var.entitycore_internal_bucket}"
   subdirectory  = "/public"
@@ -69,6 +18,16 @@ resource "aws_datasync_location_s3" "opendata_source" {
 
   s3_config {
     bucket_access_role_arn = aws_iam_role.datasync_s3_role.arn
+  }
+}
+
+resource "aws_datasync_location_s3" "cross_account_internal_destination" {
+  count         = var.datasync_target_account == "" ? 0 : 1
+  s3_bucket_arn = "arn:aws:s3:::${var.destination_entitycore_internal_bucket}"
+  subdirectory  = "/public"
+
+  s3_config {
+    bucket_access_role_arn = aws_iam_role.cross_account_datasync_s3_role[0].arn
   }
 }
 
@@ -116,6 +75,14 @@ resource "aws_datasync_task" "internal_s3_to_efs" {
     # minute | hour | day of month | month | day of week | year
     schedule_expression = "cron(0 0 ? * * *)"
   }
+}
+
+resource "aws_datasync_task" "cross_account_internal_to_s3" {
+  count                    = var.datasync_target_account == "" ? 0 : 1
+  destination_location_arn = aws_datasync_location_s3.cross_account_internal_destination[0].arn
+  source_location_arn      = aws_datasync_location_s3.internal_source.arn
+  name                     = "cross-account-s3-to-s3-sync"
+  task_mode                = "ENHANCED"
 }
 
 resource "aws_datasync_location_efs" "opendata_destination" {

--- a/public_data_sync_opendata/iam.tf
+++ b/public_data_sync_opendata/iam.tf
@@ -1,0 +1,107 @@
+resource "aws_iam_role" "datasync_s3_role" {
+  name = "datasync-s3-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "datasync.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "datasync_s3_policy" {
+  name = "datasync-s3-policy"
+  role = aws_iam_role.datasync_s3_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionTagging",
+          "s3:GetObjectTagging",
+          "s3:PutObjectTagging"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.entitycore_internal_bucket}",
+          "arn:aws:s3:::${var.entitycore_internal_bucket}/*",
+          "arn:aws:s3:::${var.opendata_bucket}",
+          "arn:aws:s3:::${var.opendata_bucket}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "cross_account_datasync_s3_role" {
+  count = var.datasync_target_account == "" ? 0 : 1
+  name  = "cross_account-datasync-s3-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "datasync.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "cross_account_datasync_s3_policy" {
+  count = var.datasync_target_account == "" ? 0 : 1
+  name  = "datasync-s3-policy"
+  role  = aws_iam_role.cross_account_datasync_s3_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionTagging",
+          "s3:GetObjectTagging",
+          "s3:PutObjectTagging"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.destination_entitycore_internal_bucket}",
+          "arn:aws:s3:::${var.destination_entitycore_internal_bucket}/*",
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceAccount" = var.datasync_target_account
+          }
+        }
+      },
+    ]
+  })
+}
+

--- a/public_data_sync_opendata/variables.tf
+++ b/public_data_sync_opendata/variables.tf
@@ -103,3 +103,15 @@ variable "azure_nfs_internal_public_data_path" {
   type        = string
   description = "NFS export path for internal_public_data on azure"
 }
+
+variable "datasync_target_account" {
+  type        = string
+  default     = ""
+  description = "Account to which datasync should sync entitycore data"
+}
+
+variable "destination_entitycore_internal_bucket" {
+  type        = string
+  default     = ""
+  description = "Destination bucket in {var.datasync_target_account} to which entitycore data needs to be synced"
+}

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -492,3 +492,21 @@ variable "resource_provisioner_container_uri" {
 variable "pcs_ami" {
   type = string
 }
+
+variable "datasync_target_account" {
+  type        = string
+  default     = ""
+  description = "Account to which datasync should sync entitycore data"
+}
+
+variable "destination_entitycore_internal_bucket" {
+  type        = string
+  default     = ""
+  description = "Destination bucket in {var.datasync_target_account} to which entitycore data needs to be synced"
+}
+
+variable "source_datasync_role" {
+  description = "IAM role to allow datasync to write to the S3 bucket. Should exist in the source account data comes from"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
The S3 bucket already exists, so we can create the DataSync objects complete with new policy that allows cross-account access

On the S3 bucket, new policy is prepared but will not be applied yet; this can only happen once the datasync role has been set up. It will require a separate commit to apply the bucket policy to the bucket by setting the `source_datasync_role` variable.