### PR TITLE
entitycore: improve healtcheck

### DIFF
--- a/entitycore_svc/alb.tf
+++ b/entitycore_svc/alb.tf
@@ -11,9 +11,13 @@ resource "aws_lb_target_group" "entitycore_private_tg" {
   }
 
   health_check {
-    enabled  = true
-    path     = "${var.root_path}/health"
-    protocol = "HTTP"
+    enabled             = true
+    path                = "${var.root_path}/health"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 10
   }
 }
 

--- a/entitycore_svc/backend.tf
+++ b/entitycore_svc/backend.tf
@@ -96,10 +96,13 @@ resource "aws_ecs_task_definition" "entitycore_ecs_definition" {
       ]
 
       healthcheck = {
-        command     = ["CMD-SHELL", "exit 0"] // TODO: add a proper health check.
-        interval    = 60
+        command = [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000${var.root_path}/health')\" || exit 1"
+        ]
+        interval    = 30
         timeout     = 5
-        startPeriod = 30
+        startPeriod = 300
         retries     = 3
       }
 
@@ -241,6 +244,9 @@ resource "aws_ecs_service" "entitycore_ecs_service" {
 
   force_new_deployment = true
   desired_count        = 1
+
+  # ignore ALB health check failures for a grace period after, to allow migrations to complete
+  health_check_grace_period_seconds = 300
 
   propagate_tags = "SERVICE"
 }

--- a/entitycore_svc/backend.tf
+++ b/entitycore_svc/backend.tf
@@ -245,7 +245,7 @@ resource "aws_ecs_service" "entitycore_ecs_service" {
   force_new_deployment = true
   desired_count        = 1
 
-  # ignore ALB health check failures for a grace period after, to allow migrations to complete
+  # ignore ALB health check failures for a grace period, to allow migrations to complete
   health_check_grace_period_seconds = 300
 
   propagate_tags = "SERVICE"


### PR DESCRIPTION
Add a health check in the task definition, besides the one in the ALB.
Increase health_check_grace_period_seconds to allow long migrations to complete.