### PR TITLE
Add ALB redirect rules for RFC 8414 OAuth metadata paths

### DIFF
--- a/cs/keycloak/alb.tf
+++ b/cs/keycloak/alb.tf
@@ -21,6 +21,46 @@ resource "aws_lb_target_group" "private_keycloak_target_group" {
   }
 }
 
+resource "aws_lb_listener_rule" "oauth_authorization_server_metadata_redirect" {
+  listener_arn = var.private_alb_https_listener_arn
+  priority     = 562
+  action {
+    type = "redirect"
+    redirect {
+      path        = "/auth/realms/${var.keycloak_realm}/.well-known/oauth-authorization-server"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/.well-known/oauth-authorization-server/auth/realms/${var.keycloak_realm}"]
+    }
+  }
+  tags = {
+    SBO_Billing = "keycloak"
+  }
+}
+
+resource "aws_lb_listener_rule" "openid_configuration_redirect" {
+  listener_arn = var.private_alb_https_listener_arn
+  priority     = 563
+  action {
+    type = "redirect"
+    redirect {
+      path        = "/auth/realms/${var.keycloak_realm}/.well-known/openid-configuration"
+      status_code = "HTTP_302"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/.well-known/openid-configuration/auth/realms/${var.keycloak_realm}"]
+    }
+  }
+  tags = {
+    SBO_Billing = "keycloak"
+  }
+}
+
 resource "aws_lb_listener_rule" "private_keycloak_https" {
   listener_arn = var.private_alb_https_listener_arn
   priority     = 565

--- a/cs/keycloak/variables.tf
+++ b/cs/keycloak/variables.tf
@@ -68,6 +68,12 @@ variable "keycloak_admin_allowed_source_ip_cidr_blocks" {
   description = "CIDRs allowed to access the Keycloak admin console"
 }
 
+variable "keycloak_realm" {
+  type        = string
+  description = "Keycloak realm name"
+  sensitive   = false
+}
+
 variable "keycloak_ecs_cluster_name" {
   type = string
 }

--- a/cs/main.tf
+++ b/cs/main.tf
@@ -104,6 +104,7 @@ module "keycloak" {
 
   keycloak_allowed_source_ip_cidr_blocks       = var.keycloak_allowed_source_ip_cidr_blocks
   keycloak_admin_allowed_source_ip_cidr_blocks = var.keycloak_admin_allowed_source_ip_cidr_blocks
+  keycloak_realm                               = "SBO"
 }
 
 module "secret_sharing_svc" {


### PR DESCRIPTION
For https://github.com/openbraininstitute/INFRA/issues/548

MCP clients (Cursor, Claude Code, etc.) probe the Authorization Server Metadata at the origin-root path per RFC8414 but Keycloak serves it under /auth/realms/SBO/ due to `KC_HTTP_RELATIVE_PATH=/auth`

So in this change we add two ALB listener rules (priority 562-563) that 302-redirect:
```
  /.well-known/oauth-authorization-server/auth/realms/{realm} -> /auth/realms/{realm}/.well-known/oauth-authorization-server
  /.well-known/openid-configuration/auth/realms/{realm}       -> /auth/realms/{realm}/.well-known/openid-configuration
```
This is the documented workaround per Keycloak 26.4.0 release notes.

