### PR TITLE
Allow incoming UDP 8443 traffic in the network ACL of the public subnets that are used by the public network load balancer

### DIFF
--- a/subnets-public.tf
+++ b/subnets-public.tf
@@ -37,6 +37,15 @@ resource "aws_network_acl" "public" {
     from_port  = 443
     to_port    = 443
   }
+  # Allow port 8443 from anywhere for Juanjo's VM
+  ingress {
+    protocol   = "udp"
+    rule_no    = 111
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 8443
+    to_port    = 8443
+  }
   # Deny RDP from anywhere
   ingress {
     protocol   = "tcp"


### PR DESCRIPTION
https://github.com/openbraininstitute/INFRA/issues/558
