### PR TITLE
Bump obi-one to v2026.6.19

### DIFF
--- a/staging.tfvars
+++ b/staging.tfvars
@@ -120,7 +120,7 @@ entitycore_svc_aws_s3_open_region        = "us-west-2"
 entitycore_svc_s3_bucket_allowed_origins = ["*"]
 entitycore_svc_image_url                 = "public.ecr.aws/openbraininstitute/entitycore:2026.6.4"
 
-obi_one_v2_docker_image_url  = "985539765147.dkr.ecr.us-east-1.amazonaws.com/obi-one:2026.6.18"
+obi_one_v2_docker_image_url  = "985539765147.dkr.ecr.us-east-1.amazonaws.com/obi-one:2026.6.19"
 obi_one_v2_ec2_instance_type = "t3.medium" # vCPUs: 2, Memory: 4 GiB
 obi_one_v2_ecs_task_size = {
   cpu    = 2048


### PR DESCRIPTION
Bumps obi-one image tag in staging.tfvars from 2026.6.18 to 2026.6.19 (released from openbraininstitute/obi-one @ main).