### PR TITLE
Add self-service redeploy role + outputs for grading-service

### DIFF
--- a/grading_service/outputs.tf
+++ b/grading_service/outputs.tf
@@ -2,3 +2,15 @@ output "private_lb_rule_suffix" {
   description = "Grading service load balancer rule suffix"
   value       = aws_lb_target_group.main.arn_suffix
 }
+
+output "ecs_cluster_name" {
+  value = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  value = aws_ecs_service.api.name
+}
+
+output "ecs_task_definition_name" {
+  value = aws_ecs_task_definition.api.family
+}

--- a/main.tf
+++ b/main.tf
@@ -388,6 +388,21 @@ module "github_keycloak_ecs_redeploy_role" {
   ecs_task_definition_name = module.cs.keycloak_ecs_task_definition_name
 }
 
+module "github_grading_service_ecs_redeploy_role" {
+  source = "./github_ecs_redeploy_role"
+
+  # Unconditional (no count): grading-service deploys to BOTH staging and
+  # production, so this role is needed in both accounts (unlike the staging-only
+  # roles above). Real tenants release to prod; the obi test tenant to staging.
+  account_id               = local.account_id
+  aws_region               = local.aws_region
+  github_organisation      = local.github_organisation
+  repo_name                = "grading-service"
+  ecs_cluster_name         = module.grading_service.ecs_cluster_name
+  ecs_service_name         = module.grading_service.ecs_service_name
+  ecs_task_definition_name = module.grading_service.ecs_task_definition_name
+}
+
 
 module "hpc" {
   source = "./hpc"

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,10 @@ output "keycloak_redeploy_role" {
   value = var.is_staging ? module.github_keycloak_ecs_redeploy_role[0] : null
 }
 
+output "grading_service_redeploy_role_arn" {
+  value = module.github_grading_service_ecs_redeploy_role.github_role_arn
+}
+
 output "github_core_web_app_preview_deploy_role_arn" {
   value = var.is_staging ? module.core_webapp_preview[0].github_deploy_role_arn : null
 


### PR DESCRIPTION
## What

Enables the **grading-service** CI (`openbraininstitute/grading-service`) to roll out its own ECS deployments without a per-release Terraform apply. This is the one-time, infra-side half of the self-service release contract.

- **Redeploy IAM role** — instantiate `github_ecs_redeploy_role` for grading-service, **unconditionally** (no `count`/`is_staging` gate) so the role is created in **both** the staging and production accounts. Real tenants release to prod; the obi test tenant to staging. The role trusts only `repo:openbraininstitute/grading-service:*` via OIDC and can do nothing but force a new deployment of this one service (`ecs:UpdateService` / `DescribeServices` / `DescribeTaskDefinition` / `DescribeClusters`, scoped to the single service/cluster/task-def). No image push, no other service, no cross-repo access.
  - Role name: `gh_redeploy_ecs_api_grading-service`.
- **Outputs** — export `ecs_cluster_name` / `ecs_service_name` / `ecs_task_definition_name` from the `grading_service` module, and `grading_service_redeploy_role_arn` from the root, so the team can wire the ARN into their GitHub Environments.

## Why unconditional (differs from notebook-service / keycloak roles)

The existing redeploy roles are `count = var.is_staging ? 1 : 0` because they only redeploy in staging. grading-service releases to **both** environments, so the role (and its output) must exist in both accounts — hence no gate, and the output references the module directly (no `[0]` index).

## Blast radius

None to running infrastructure. `terraform plan` shows only the new IAM role + inline policy and the new outputs — **no change** to the grading-service ECS service or task definition.

## Expected role ARNs (one per account)

- staging: `arn:aws:iam::992382665735:role/gh_redeploy_ecs_api_grading-service`
- production: `arn:aws:iam::671250183987:role/gh_redeploy_ecs_api_grading-service`

## Sequencing

This is **step 1** of 2. It is safe to merge/apply now and does not touch the running service. The image flip to the rolling `:staging` / `:prod` alias is a separate, **held** PR that must only merge **after** the grading-service CI has pushed those aliases to ECR.