### PR TITLE
Fix PCS resource creation in sandbox-nse

### DIFF
--- a/launch_system/pcs.tf
+++ b/launch_system/pcs.tf
@@ -185,6 +185,10 @@ resource "awscc_pcs_queue" "pcs_queue_small" {
   ]
   name = "pcs-queue-small"
   tags = { SBO_Billing = "pcs-hpc" }
+
+  lifecycle {
+    replace_triggered_by = [awscc_pcs_compute_node_group.pcs_nodegroup_small]
+  }
 }
 
 resource "awscc_pcs_compute_node_group" "pcs_nodegroup_large" {
@@ -193,15 +197,23 @@ resource "awscc_pcs_compute_node_group" "pcs_nodegroup_large" {
   cluster_id = awscc_pcs_cluster.cluster.cluster_id
 
   custom_launch_template = {
-    template_id = aws_launch_template.pcs_launch_template_efa.id
-    version     = aws_launch_template.pcs_launch_template_efa.latest_version
+    template_id = (
+      var.pcs_large_enable_efa ?
+      aws_launch_template.pcs_launch_template_efa.id :
+      aws_launch_template.pcs_launch_template.id
+    )
+    version = (
+      var.pcs_large_enable_efa ?
+      aws_launch_template.pcs_launch_template_efa.latest_version :
+      aws_launch_template.pcs_launch_template.latest_version
+    )
   }
 
   iam_instance_profile_arn = aws_iam_instance_profile.pcs_profile.arn
 
   instance_configs = [
     {
-      instance_type = "hpc7a.96xlarge"
+      instance_type = var.pcs_large_instance_type
     },
   ]
 
@@ -235,6 +247,10 @@ resource "awscc_pcs_queue" "pcs_queue_large" {
   ]
   name = "pcs-queue-large"
   tags = { SBO_Billing = "pcs-hpc" }
+
+  lifecycle {
+    replace_triggered_by = [awscc_pcs_compute_node_group.pcs_nodegroup_large]
+  }
 }
 
 locals {
@@ -291,6 +307,10 @@ resource "awscc_pcs_queue" "pcs_queue_large_fallback" {
   ]
   name = "pcs-q-large-${each.key}"
   tags = { SBO_Billing = "pcs-hpc" }
+
+  lifecycle {
+    replace_triggered_by = [awscc_pcs_compute_node_group.pcs_ng_large_fallback[each.key]]
+  }
 }
 
 resource "aws_s3_bucket" "pcs_fsx_data" {
@@ -352,6 +372,11 @@ resource "aws_fsx_data_repository_association" "pcs_s3" {
 
   imported_file_chunk_size = 1024
   tags                     = { SBO_Billing = "hpc" }
+
+  timeouts {
+    create = "20m"
+    delete = "20m"
+  }
 }
 
 resource "aws_iam_role" "fsx_s3" {

--- a/launch_system/variables.tf
+++ b/launch_system/variables.tf
@@ -270,3 +270,13 @@ variable "pcs_large_nodes_max_instance_count" {
   description = "Maximum number of cluster nodes for large instances"
   type        = number
 }
+
+variable "pcs_large_instance_type" {
+  description = "EC2 instance type for the large PCS compute node group"
+  type        = string
+}
+
+variable "pcs_large_enable_efa" {
+  description = "Whether to use the EFA-enabled launch template for the large PCS node group"
+  type        = bool
+}

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   aws_region = data.aws_region.current.region
   vpc_id     = data.terraform_remote_state.common.outputs.vpc_id
 
-  suffix = var.is_staging ? "-staging" : var.is_production ? "production" : ""
+  suffix = var.is_staging ? "-staging" : var.is_production ? "production" : var.deployment_env
 
   private_alb_https_listener_arn = data.terraform_remote_state.common.outputs.private_alb_https_listener_arn
   route_table_private_subnets_id = data.terraform_remote_state.common.outputs.route_table_private_subnets_id
@@ -825,9 +825,13 @@ module "launch_system" {
 
   cluster_task_maximum_runtime = 86400
 
-  entitycore_url        = "https://${local.cell_a_primary_domain}/api/entitycore"
-  auth_manager_url      = "https://${local.cell_a_primary_domain}/api/auth-manager"
-  launch_system_api_url = "https://${local.cell_a_primary_domain}/api/launch-system"
+  entitycore_url   = "https://${local.cell_a_primary_domain}/api/entitycore"
+  auth_manager_url = "https://${local.cell_a_primary_domain}/api/auth-manager"
+  launch_system_api_url = (
+    (var.is_staging || var.is_production) ?
+    "https://${local.cell_a_primary_domain}/api/launch-system" :
+    "https://${var.deployment_env}.cell-a.openbraininstitute.org/api/launch-system"
+  )
 
   local_store_prefix        = "/data"
   simulation_launch_command = "/data/scratch/run-simulation-venv/bin/python3 /data/scratch/run_simulation.py"
@@ -837,6 +841,8 @@ module "launch_system" {
   pcs_cidr_block                     = "10.0.36.0/24"
   pcs_fsx_scratch_s3_bucket_name     = "obi-pcs-scratch-fsx-${local.suffix}"
   pcs_large_nodes_max_instance_count = 20
+  pcs_large_instance_type            = var.pcs_large_instance_type
+  pcs_large_enable_efa               = var.pcs_large_enable_efa
   pcs_large_alternate_node_types     = [] # no alternates since we are using `hpc7a.96xlarge`
 
   codeartifact_config = {

--- a/production.tfvars
+++ b/production.tfvars
@@ -165,7 +165,9 @@ azure_nfs_internal_public_data_path = "/obibatchnfsprod/publicdata"
 resource_provisioner_container_hash = "1837363b2413d5e7cfd8c7a859ba4b3cd35c685acd4240f70101364aaaeee0b8"
 resource_provisioner_container_uri  = "985539765147.dkr.ecr.us-east-1.amazonaws.com/hpc-resource-provisioner:0.5.13.dev8"
 
-pcs_ami = "ami-09d9c5c263e321fd4"
+pcs_ami                 = "ami-09d9c5c263e321fd4"
+pcs_large_instance_type = "hpc7a.96xlarge"
+pcs_large_enable_efa    = true
 
 datasync_target_account                = "992382665735"
 destination_entitycore_internal_bucket = "entitycore-data-staging"

--- a/sandbox-nse.tfvars
+++ b/sandbox-nse.tfvars
@@ -135,4 +135,6 @@ azure_nfs_internal_public_data_path                = "/obibatchnfsstg/publicdata
 resource_provisioner_container_hash                = "1837363b2413d5e7cfd8c7a859ba4b3cd35c685acd4240f70101364aaaeee0b8"
 resource_provisioner_container_uri                 = "985539765147.dkr.ecr.us-east-1.amazonaws.com/hpc-resource-provisioner:0.5.13.dev8"
 
-pcs_ami = "ami-0d196e97f4b5b69b4"
+pcs_ami                 = "ami-0fa11a6354572d8b5"
+pcs_large_instance_type = "c5n.large" # 2 vCPUs, 5.3 GiB
+pcs_large_enable_efa    = false

--- a/staging.tfvars
+++ b/staging.tfvars
@@ -168,4 +168,6 @@ azure_nfs_internal_public_data_path = "/obibatchnfsstg/publicdata"
 resource_provisioner_container_hash = "1837363b2413d5e7cfd8c7a859ba4b3cd35c685acd4240f70101364aaaeee0b8"
 resource_provisioner_container_uri  = "985539765147.dkr.ecr.us-east-1.amazonaws.com/hpc-resource-provisioner:0.5.13.dev8"
 
-pcs_ami = "ami-01d53dbbc31fea9f1"
+pcs_ami                 = "ami-01d53dbbc31fea9f1"
+pcs_large_instance_type = "hpc7a.96xlarge"
+pcs_large_enable_efa    = true

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -481,6 +481,15 @@ variable "pcs_ami" {
   type = string
 }
 
+variable "pcs_large_instance_type" {
+  description = "EC2 instance type for the large PCS compute node group"
+  type        = string
+}
+
+variable "pcs_large_enable_efa" {
+  description = "Whether to use the EFA-enabled launch template for the large PCS node group"
+  type        = bool
+}
 variable "datasync_target_account" {
   type        = string
   default     = ""


### PR DESCRIPTION
Fixes errors when deploying `module.launch_system` PCS resources in the sandbox-nse environment:

### Changes

- **Fix invalid S3 bucket name**: `local.suffix` produced an empty string for non-staging/non-production environments, resulting in a trailing hyphen (`obi-pcs-scratch-fsx-`). Now uses `var.deployment_env` as suffix.
- **Make PCS large instance type configurable**: Extracted the hardcoded `hpc7a.96xlarge` into a new `pcs_large_instance_type` variable, allowing sandbox to use a smaller instance type (`c5n.large`).
- **Make EFA optional for large node group**: Added `pcs_large_enable_efa` variable to switch between EFA and non-EFA launch templates. EFA requires specific (large/expensive) instance types not needed in sandbox.
- **Fix FSx Data Repository Association timeout**: Increased create/delete timeout from 10m to 20m to accommodate slower provisioning.
- **Add `replace_triggered_by` on PCS queues**: Ensures queues are automatically replaced when their associated node groups change (e.g. AMI or instance type update), preventing `ResourceConflict` errors during apply.

### Environment settings

| Variable | sandbox-nse | staging/production |
|----------|------------|-------------------|
| `pcs_large_instance_type` | `c5n.large` | `hpc7a.96xlarge` |
| `pcs_large_enable_efa` | `false` | `true` |
