### PR TITLE
launch-system: allow the orchestrator to delete task definitions

### DIFF
--- a/launch_system/orchestrator.tf
+++ b/launch_system/orchestrator.tf
@@ -333,6 +333,8 @@ resource "aws_iam_policy" "orchestrator_ecs_run_task" {
           "ecs:RegisterTaskDefinition",
           "ecs:DescribeTaskDefinition",
           "ecs:ListTaskDefinitions",
+          "ecs:DeregisterTaskDefinition",
+          "ecs:DeleteTaskDefinitions",
         ]
         Resource = ["*"]
       },


### PR DESCRIPTION
Needed to cleanup old task definitions created dynamically in https://github.com/openbraininstitute/launch-system/pull/186