### PR TITLE
Use main preview deployment as an auth proxy

### DIFF
--- a/core_webapp_preview/main.tf
+++ b/core_webapp_preview/main.tf
@@ -76,7 +76,7 @@ resource "aws_amplify_app" "this" {
     KEYCLOAK_CLIENT_ID     = var.keycloak_client_id
     KEYCLOAK_CLIENT_SECRET = jsondecode(data.aws_secretsmanager_secret_version.secrets.secret_string)["client_secret_cellb_azure_staging"]
     NEXTAUTH_SECRET        = jsondecode(data.aws_secretsmanager_secret_version.secrets.secret_string)["nextauth_secret"]
-    AUTH_PROXY_URL         = "https://develop.${var.domain_name}"
+    AUTH_PROXY_URL         = "https://main.${var.domain_name}"
 
     GRADING_WEB_LAUNCH_HMAC_SECRET = jsondecode(data.aws_secretsmanager_secret_version.secrets.secret_string)["GRADING_WEB_LAUNCH_HMAC_SECRET"]
   }


### PR DESCRIPTION
The dev branch is no longer used on is not receiving any updates - potentially will be deleted.
So we are switching to use main preview deployment to be used as an auth proxy.