### PR TITLE
update: allow wildcard localhost for all services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,8 @@ locals {
   core_web_app_origins = concat(
     ["https://${local.public_primary_domain_in_azure}"],
     var.is_staging ? [
-      "http://127.0.0.1:3000",
-      "http://localhost:3000",
+      "http://127.0.0.1:*",
+      "http://localhost:*",
       "https://preview.openbraininstitute.org",
       "https://*.preview.openbraininstitute.org",
       "https://staging.cell-b.openbraininstitute.org",


### PR DESCRIPTION
updates the staging `cors` configuration to accept any port on `localhost` and `127.0.0.1` instead of being restricted to port 3000 only

this unblocks local development when running frontend on non-standard ports (e.g. 3001, 8000, ...) 
specially when the dev try to develop multiple features in the same time

**changes:**
- `http://localhost:3000` → `http://localhost:*`
- `http://127.0.0.1:3000` → `http://127.0.0.1:*`

@jankrepl (ML) 
@GianlucaFicarelli (entitycore) 
@pgetta (small_scale_simulator) 
@DriesVerachtert (notebook_service)

@danifr  can you confirm whether Keycloak is already configured to allow wildcard redirects for authentication ?