### PR TITLE
Allow Launch System API to reach accounting service, reject non-allowlisted IPs with 403

### DIFF
--- a/accounting_svc/alb.tf
+++ b/accounting_svc/alb.tf
@@ -43,3 +43,28 @@ resource "aws_lb_listener_rule" "accounting_private_listener_rule" {
     }
   }
 }
+
+# Requests to the accounting path that did not match any source_ip allowlist
+# rule above are explicitly rejected instead of falling through to the
+# listener default action. Priority must stay above the highest possible
+# chunk rule (base + chunk_index) and below other services' rules (700+).
+resource "aws_lb_listener_rule" "accounting_private_listener_rule_deny" {
+  listener_arn = var.private_alb_listener_arn
+  priority     = var.listener_rule_base_priority + 40
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "application/json"
+      message_body = "{\"detail\": \"Forbidden\"}"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["${var.root_path}*"]
+    }
+  }
+}

--- a/launch_system/outputs.tf
+++ b/launch_system/outputs.tf
@@ -26,6 +26,14 @@ output "orchestrator_subnet_cidr_blocks" {
   ]
 }
 
+output "api_subnet_cidr_blocks" {
+  description = "CIDR blocks of the launch_system API (trusted) subnets"
+  value = [
+    aws_subnet.trusted_a.cidr_block,
+    aws_subnet.trusted_b.cidr_block,
+  ]
+}
+
 output "pcs_subnet_cidr_block" {
   description = "CIDR block of the PCS subnet"
   value       = aws_subnet.pcs.cidr_block

--- a/main.tf
+++ b/main.tf
@@ -499,6 +499,7 @@ module "accounting_svc" {
     module.ml_typescript.subnet_cidr_blocks,
     module.notebook_service.subnet_cidr_blocks,
     module.virtual_lab_manager.subnet_cidr_blocks,
+    module.launch_system.api_subnet_cidr_blocks,
     ["${module.bastion_host.bastion_instance_private_ip}/32"],
     [var.core_web_app_in_azure_cidr_block],
   )


### PR DESCRIPTION
## What

- Export the launch_system API (trusted) subnet CIDRs as `api_subnet_cidr_blocks` and add them to the accounting service ALB `source_ip` allowlist, so the Launch System API can call the accounting service through the private ALB.
- Add an explicit `fixed-response` deny rule for `/api/accounting*` at priority 690: requests from IPs outside the allowlist now get `403 {"detail": "Forbidden"}` instead of falling through to the listener default action.

## Notes

- The allowlist grows from ~12 to ~14 CIDRs, so the chunked forward rules gain a 4th rule at priority 653 (chunks of 4, base 650). The deny rule sits at a fixed offset (base + 40 = 690) so allowlist growth can never collide with it, and stays below the next service's priority (700, cells_svc).
- 403 chosen over 404/401: the request is refused on authorization grounds (IP allowlist), matching AWS WAF convention and keeping allowlist misconfigurations easy to diagnose on the internal ALB.

P.S. It turns out that [Only allow a list of services to access accounting and launch-system
](https://github.com/openbraininstitute/aws-terraform-deployment/pull/1281) had introduced a regression where the Launch System API could no longer communicate with the accounting service which caused an issue with reservation cancellation for failed tasks.